### PR TITLE
feat(plotting): create plotting page, enhance import UI, add template…

### DIFF
--- a/src/app/api/asprak/route.ts
+++ b/src/app/api/asprak/route.ts
@@ -10,8 +10,14 @@ import { logger } from '@/lib/logger';
 export async function GET(req: Request) {
   try {
     const url = new URL(req.url);
-    const action = url.searchParams.get('action');
-    const term = url.searchParams.get('term') || undefined;
+    const params = url.searchParams;
+    const action = params.get('action');
+    const term = params.get('term') || undefined;
+
+    if (action === 'plotting') {
+      const data = await asprakService.getAspraksWithAssignments(term);
+      return NextResponse.json({ data });
+    }
 
     if (action === 'codes') {
       const codes = await asprakService.getExistingCodes();

--- a/src/app/api/plotting/route.ts
+++ b/src/app/api/plotting/route.ts
@@ -1,0 +1,61 @@
+
+import { NextResponse } from 'next/server';
+import * as plottingService from '@/services/plottingService';
+import { logger } from '@/lib/logger';
+
+export async function GET(req: Request) {
+  try {
+    const url = new URL(req.url);
+    const term = url.searchParams.get('term') || undefined;
+    const page = parseInt(url.searchParams.get('page') || '1');
+    const limit = parseInt(url.searchParams.get('limit') || '1000'); // Default high for client side pagination if needed
+
+    // If we use server side pagination:
+    // const result = await plottingService.getPlottingList(page, limit, term);
+    
+    // But currently frontend uses grouped data from asprakService?
+    // User requested "pagination like asprak page". Asprak page fetches ALL and client paginates.
+    // So we can return ALL here or use the existing asprakService.
+    
+    // Actually, let's expose the service we created (getPlottingList) which returns FLAT assignment rows.
+    // This might be different from grouped view.
+    // If the table should look like AsprakTable (Row = Asprak), we should fetch aggregated.
+    // getPlottingList returns Row = Assignment.
+    
+    // If we want Row = Asprak (with assignments inside), we need aggregation.
+    // PlottingPage currently uses fetchPlottingData -> calls asprakService.getAspraksWithAssignments.
+    
+    // I will stick to getAspraksWithAssignments logic but move it here? 
+    // Or just use this route for Transactional/Validation stuff.
+    // User asked "plotting page ... turunan sidebar ... input manual ... import csv ... validasi".
+    
+    // Let's implement validation actions here.
+    return NextResponse.json({ message: "Use action POST for validation" });
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 500 });
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const { action } = body;
+
+    if (action === 'validate-import') {
+        const { rows, term } = body; // rows: { kode_asprak, mk_singkat }[]
+        const result = await plottingService.validatePlottingImport(rows, term);
+        return NextResponse.json(result);
+    }
+    
+    if (action === 'save-plotting') {
+        const { assignments } = body; // { asprak_id, praktikum_id }[]
+        await plottingService.savePlotting(assignments);
+        return NextResponse.json({ success: true });
+    }
+
+    return NextResponse.json({ error: 'Invalid action' }, { status: 400 });
+  } catch (e: any) {
+    logger.error('POST /api/plotting error:', e);
+    return NextResponse.json({ error: e.message }, { status: 500 });
+  }
+}

--- a/src/app/plotting/page.tsx
+++ b/src/app/plotting/page.tsx
@@ -1,0 +1,141 @@
+
+'use client';
+
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import { useAsprak } from '@/hooks/useAsprak';
+import { usePraktikum } from '@/hooks/usePraktikum';
+import { fetchPlottingData, AsprakPlottingData } from '@/lib/fetchers/asprakFetcher';
+import PlottingFilters from '@/components/plotting/PlottingFilters';
+import PlottingTable from '@/components/plotting/PlottingTable';
+import PlottingImportModal from '@/components/plotting/PlottingImportModal';
+import PlottingManualModal from '@/components/plotting/PlottingManualModal';
+import { Plus, Upload } from 'lucide-react';
+import { toast } from 'sonner';
+
+export default function PlottingPage() {
+  const { terms, selectedTerm, setSelectedTerm } = useAsprak(); 
+  const { getPraktikumByTerm } = usePraktikum(); 
+
+  const [data, setData] = useState<AsprakPlottingData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState('');
+  
+  // Praktikum Filter State
+  const [praktikums, setPraktikums] = useState<{id: string, nama: string}[]>([]);
+  const [selectedPraktikum, setSelectedPraktikum] = useState('all');
+
+  // Modals
+  const [showImport, setShowImport] = useState(false);
+  const [showManual, setShowManual] = useState(false);
+
+  // Fetch Data
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    const term = selectedTerm === 'all' ? undefined : selectedTerm;
+    const result = await fetchPlottingData(term);
+    if (result.ok && result.data) {
+        setData(result.data);
+    } else {
+        toast.error("Failed to load plotting data");
+    }
+    setLoading(false);
+  }, [selectedTerm]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]); // selectedTerm dependency via loadData
+
+  // Update Praktikum List when Term Changes
+  useEffect(() => {
+      const termArg = selectedTerm === '' ? 'all' : selectedTerm; 
+      getPraktikumByTerm(termArg).then(data => {
+          setPraktikums(data || []);
+      });
+      setSelectedPraktikum('all'); 
+  }, [selectedTerm, getPraktikumByTerm]);
+
+  // Client-side Filtering
+  const filteredData = useMemo(() => {
+      let result = data;
+
+      // Filter by Praktikum (if selected)
+      if (selectedPraktikum !== 'all') {
+          // Filter Aspraks who have THIS assignment
+          result = result.filter(asprak => 
+              asprak.assignments.some(a => a.id === selectedPraktikum)
+          );
+      }
+
+      // Filter by Search
+      if (searchQuery) {
+          const q = searchQuery.toLowerCase();
+          result = result.filter(item => 
+              item.nama_lengkap.toLowerCase().includes(q) ||
+              item.nim.includes(q) ||
+              item.kode.toLowerCase().includes(q) ||
+              item.assignments.some(a => a.nama.toLowerCase().includes(q))
+          );
+      }
+      
+      return result;
+  }, [data, selectedPraktikum, searchQuery]);
+
+  return (
+    <div className="container py-6 space-y-6">
+       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight title-gradient">Plotting Asprak</h1>
+            <p className="text-muted-foreground">Manage assistant course assignments</p>
+          </div>
+          <div className="flex gap-2">
+              <Button variant="outline" onClick={() => setShowManual(true)}>
+                  <Plus className="mr-2 h-4 w-4" /> Input Manual
+              </Button>
+              <Button onClick={() => setShowImport(true)}>
+                  <Upload className="mr-2 h-4 w-4" /> Import CSV
+              </Button>
+          </div>
+       </div>
+
+       <div className="card glass p-6">
+           <PlottingFilters
+                searchQuery={searchQuery}
+                onSearchChange={setSearchQuery}
+                terms={terms}
+                selectedTerm={selectedTerm}
+                onTermChange={setSelectedTerm}
+                praktikums={praktikums}
+                selectedPraktikum={selectedPraktikum}
+                onPraktikumChange={setSelectedPraktikum}
+           />
+
+           <div className="mt-6">
+               <PlottingTable 
+                   data={filteredData} 
+                   loading={loading} 
+                   term={selectedTerm}
+               />
+           </div>
+       </div>
+       
+       <PlottingImportModal 
+           open={showImport} 
+           onOpenChange={setShowImport} 
+           onSuccess={() => {
+               loadData(); 
+           }}
+           terms={terms}
+       />
+       
+       <PlottingManualModal
+           open={showManual}
+           onOpenChange={setShowManual} 
+           onSuccess={() => {
+               loadData();
+           }}
+           terms={terms}
+       />
+    </div>
+  );
+}

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Home, Users, Calendar, AlertTriangle, Database, BookOpen } from 'lucide-react';
+import { Home, Users, Calendar, AlertTriangle, Database, BookOpen, Network } from 'lucide-react';
 
 import {
   Sidebar,
@@ -39,10 +39,11 @@ const navItems: NavItem[] = [
     icon: Users,
     items: [
       { label: 'Data Asprak', href: '/asprak?tab=data' },
+      { label: 'Plotting Asprak', href: '/plotting' },
       { label: 'Aturan Generasi', href: '/asprak?tab=rules' },
     ]
   },
-  { label: 'Data Praktikum', href: '/praktikum', icon: BookOpen }, // Added this
+  { label: 'Data Praktikum', href: '/praktikum', icon: BookOpen },
   { label: 'Jadwal Praktikum', href: '/jadwal', icon: Calendar },
   { label: 'Pelanggaran', href: '/pelanggaran', icon: AlertTriangle },
   { label: 'Database Manager', href: '/database', icon: Database },

--- a/src/components/plotting/PlottingCSVPreview.tsx
+++ b/src/components/plotting/PlottingCSVPreview.tsx
@@ -1,0 +1,204 @@
+
+import { Checkbox } from '@/components/ui/checkbox';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { CheckCircle, AlertTriangle, ArrowLeft, Save, XCircle, HelpCircle } from 'lucide-react';
+
+export interface PlottingPreviewRow {
+  index: number;
+  kode_asprak: string;
+  mk_singkat: string;
+  status: 'valid' | 'invalid' | 'ambiguous';
+  message?: string;
+  candidates?: { id: string; nama_lengkap: string; nim: string; angkatan: number }[];
+  selectedCandidateIds?: string[];
+  selected: boolean;
+}
+
+interface PlottingCSVPreviewProps {
+  rows: PlottingPreviewRow[];
+  term: string;
+  onConfirm: () => void;
+  onBack: () => void;
+  onResolve: (rowIndex: number, candidateId: string) => void;
+  onToggleSelect: (rowIndex: number) => void;
+  onToggleAll: (checked: boolean) => void;
+  loading: boolean;
+}
+
+export default function PlottingCSVPreview({
+  rows,
+  term,
+  onConfirm,
+  onBack,
+  onResolve,
+  onToggleSelect,
+  onToggleAll,
+  loading,
+}: PlottingCSVPreviewProps) {
+  const totalValid = rows.filter(r => r.status === 'valid').length;
+  // Resolved ambiguous rows count as valid for saving purposes?
+  // Or just display "Ambiguous" count but with candidates selected?
+  // User wants to see what's happening.
+  // I'll keep them as 'ambiguous' status visually until resolved? 
+  // Or if selectedCandidateIds > 0, consider them resolved?
+  // The logic in parent `handleConfirm` handles saving.
+  // Visual counts:
+  const totalAmbiguous = rows.filter(r => r.status === 'ambiguous').length;
+  const totalInvalid = rows.filter(r => r.status === 'invalid').length;
+  
+  const selectableRows = rows.filter(r => r.status !== 'invalid');
+  const selectedCount = selectableRows.filter(r => r.selected).length;
+  
+  // Count actually savable assignments (Valid rows + Selected Candidates in Ambiguous rows)
+  // Logic: Valid Row = 1 assignment. Ambiguous Row = N assignments (where N = selectedCandidateIds.length).
+  // Only if row.selected is true.
+  
+  let validAssignmentsCount = 0;
+  rows.forEach(r => {
+      if (!r.selected) return;
+      if (r.status === 'valid') validAssignmentsCount++;
+      if (r.status === 'ambiguous' && r.selectedCandidateIds) {
+          validAssignmentsCount += r.selectedCandidateIds.length;
+      }
+  });
+
+  const allSelected = selectableRows.length > 0 && selectedCount === selectableRows.length;
+  const isIndeterminate = selectedCount > 0 && selectedCount < selectableRows.length;
+
+  return (
+    <div className="space-y-4">
+      {/* Summary Header */}
+      <div className="flex flex-wrap gap-3 items-center">
+        <Badge variant="outline" className="text-sm px-3 py-1">
+          Term: <span className="font-bold ml-1">{term}</span>
+        </Badge>
+        <Badge variant="outline" className="text-sm px-3 py-1">
+          Total Rows: <span className="font-bold ml-1">{rows.length}</span>
+        </Badge>
+        
+        {totalValid > 0 && (
+           <Badge className="bg-emerald-500/10 text-emerald-500 border-emerald-500/30 text-sm px-3 py-1">
+             <CheckCircle size={14} className="mr-1" /> {totalValid} Valid
+           </Badge>
+        )}
+        {totalAmbiguous > 0 && (
+           <Badge className="bg-amber-500/10 text-amber-500 border-amber-500/30 text-sm px-3 py-1">
+             <HelpCircle size={14} className="mr-1" /> {totalAmbiguous} Ambiguous
+           </Badge>
+        )}
+        {totalInvalid > 0 && (
+           <Badge className="bg-red-500/10 text-red-500 border-red-500/30 text-sm px-3 py-1">
+             <XCircle size={14} className="mr-1" /> {totalInvalid} Invalid
+           </Badge>
+        )}
+      </div>
+
+      {/* Table */}
+      <div className="rounded-lg border border-border overflow-hidden">
+        <div className="overflow-x-auto max-h-[400px] overflow-y-auto">
+          <table className="w-full text-sm border-collapse">
+            <thead className="bg-muted/50 sticky top-0 z-10">
+              <tr>
+                <th className="px-3 py-2.5 text-center border-b w-[40px]">
+                  <Checkbox 
+                    checked={allSelected ? true : isIndeterminate ? "indeterminate" : false}
+                    onCheckedChange={(c) => onToggleAll(!!c)}
+                    disabled={selectableRows.length === 0}
+                  />
+                </th>
+                <th className="px-3 py-2.5 text-left border-b w-10 text-muted-foreground">#</th>
+                <th className="px-3 py-2.5 text-left border-b text-muted-foreground uppercase text-xs font-semibold">Kode Asprak</th>
+                <th className="px-3 py-2.5 text-left border-b text-muted-foreground uppercase text-xs font-semibold">Mata Kuliah</th>
+                <th className="px-3 py-2.5 text-left border-b text-muted-foreground uppercase text-xs font-semibold">Status</th>
+                <th className="px-3 py-2.5 text-left border-b text-muted-foreground uppercase text-xs font-semibold w-[350px]">Resolution (Select Candidates)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row, idx) => {
+                const isDisabled = row.status === 'invalid';
+                const isAmbiguous = row.status === 'ambiguous';
+                
+                return (
+                  <tr key={idx} className={`
+                     border-b border-border/50 transition-colors
+                     ${row.status === 'invalid' ? 'bg-red-500/5' : ''}
+                     ${row.status === 'ambiguous' ? 'bg-amber-500/5' : ''}
+                     ${!isDisabled && row.selected ? 'bg-muted/40' : ''}
+                     hover:bg-muted/60
+                  `}>
+                    <td className="px-3 py-2 text-center align-top pt-3">
+                      <Checkbox 
+                        checked={row.selected}
+                        onCheckedChange={() => onToggleSelect(idx)}
+                        disabled={isDisabled}
+                        className={isDisabled ? "opacity-50" : ""}
+                      />
+                    </td>
+                    <td className="px-3 py-2 text-muted-foreground font-mono text-xs align-top pt-3">{idx + 1}</td>
+                    <td className="px-3 py-2 font-mono font-bold align-top pt-3">{row.kode_asprak}</td>
+                    <td className="px-3 py-2 font-mono align-top pt-3">{row.mk_singkat}</td>
+                    <td className="px-3 py-2 align-top pt-3">
+                       {row.status === 'valid' && <span className="text-emerald-500 flex items-center gap-1"><CheckCircle size={14}/> Valid</span>}
+                       {row.status === 'invalid' && <span className="text-red-500 flex items-center gap-1" title={row.message}><XCircle size={14}/> {row.message || 'Error'}</span>}
+                       {row.status === 'ambiguous' && <span className="text-amber-500 flex items-center gap-1"><HelpCircle size={14}/> Ambiguous</span>}
+                    </td>
+                    <td className="px-3 py-2">
+                       {isAmbiguous && row.candidates && (
+                          <div className="flex flex-col gap-2 border rounded-md p-2 bg-background/50">
+                              {row.candidates.map(c => {
+                                  const isSelected = row.selectedCandidateIds?.includes(c.id);
+                                  return (
+                                     <div key={c.id} className="flex items-start space-x-2">
+                                         <Checkbox 
+                                            id={`row-${idx}-cand-${c.id}`}
+                                            checked={isSelected}
+                                            onCheckedChange={() => onResolve(idx, c.id)}
+                                         />
+                                         <div className="grid gap-0.5 leading-none">
+                                             <Label 
+                                                htmlFor={`row-${idx}-cand-${c.id}`}
+                                                className="text-xs font-medium cursor-pointer"
+                                             >
+                                                {c.nama_lengkap}
+                                             </Label>
+                                             <span className="text-[10px] text-muted-foreground font-mono">
+                                                NIM: {c.nim} | Angkatan: {c.angkatan}
+                                             </span>
+                                         </div>
+                                     </div>
+                                  );
+                              })}
+                          </div>
+                       )}
+                       {!isAmbiguous && row.message && row.status !== 'valid' && (
+                           <span className="text-xs text-muted-foreground truncate max-w-[280px] block" title={row.message}>
+                               {row.message}
+                           </span>
+                       )}
+                       {!isAmbiguous && row.status === 'valid' && row.message && (
+                           <span className="text-xs text-muted-foreground">{row.message}</span>
+                       )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Footer Actions */}
+      <div className="flex justify-between items-center pt-2">
+         <Button variant="outline" onClick={onBack} disabled={loading}>
+             <ArrowLeft size={16} className="mr-1" /> Back
+         </Button>
+         <Button onClick={onConfirm} disabled={loading || validAssignmentsCount === 0} variant="default">
+             <Save size={16} className="mr-1" />
+             {loading ? 'Saving...' : `Save ${validAssignmentsCount} Assignments`}
+         </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/plotting/PlottingFilters.tsx
+++ b/src/components/plotting/PlottingFilters.tsx
@@ -1,0 +1,90 @@
+
+import { Search } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+interface PlottingFiltersProps {
+  searchQuery: string;
+  onSearchChange: (query: string) => void;
+  terms: string[];
+  selectedTerm: string;
+  onTermChange: (term: string) => void;
+  praktikums: { id: string; nama: string }[];
+  selectedPraktikum: string;
+  onPraktikumChange: (id: string) => void;
+}
+
+export default function PlottingFilters({
+  searchQuery,
+  onSearchChange,
+  terms,
+  selectedTerm,
+  onTermChange,
+  praktikums,
+  selectedPraktikum,
+  onPraktikumChange,
+}: PlottingFiltersProps) {
+  return (
+    <div className="flex flex-col gap-4 pb-6 border-b border-border">
+       <div className="flex flex-col sm:flex-row gap-4">
+          {/* Search */}
+          <div className="relative flex-1">
+            <Search
+                size={18}
+                className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+            />
+            <Input
+                type="text"
+                placeholder="Search asprak, code, or course..."
+                value={searchQuery}
+                onChange={(e) => onSearchChange(e.target.value)}
+                className="pl-10 h-10"
+            />
+          </div>
+          
+          <div className="flex gap-2">
+              {/* Term Filter */}
+              <Select value={selectedTerm} onValueChange={onTermChange}>
+                <SelectTrigger className="w-[160px] h-10">
+                    <SelectValue placeholder="Select term" />
+                </SelectTrigger>
+                <SelectContent>
+                    <SelectGroup>
+                    <SelectItem value="all">All Terms</SelectItem>
+                    {terms.map((term) => (
+                        <SelectItem key={term} value={term}>
+                        {term}
+                        </SelectItem>
+                    ))}
+                    </SelectGroup>
+                </SelectContent>
+              </Select>
+              
+              {/* Praktikum Filter */}
+              <Select value={selectedPraktikum} onValueChange={onPraktikumChange}>
+                <SelectTrigger className="w-[200px] h-10">
+                    <SelectValue placeholder="All Courses" />
+                </SelectTrigger>
+                <SelectContent>
+                    <SelectGroup>
+                    <SelectItem value="all">All Courses</SelectItem>
+                    {praktikums.map((p) => (
+                        <SelectItem key={p.id} value={p.id}>
+                        {p.nama}
+                        </SelectItem>
+                    ))}
+                    </SelectGroup>
+                </SelectContent>
+              </Select>
+          </div>
+       </div>
+    </div>
+  );
+}

--- a/src/components/plotting/PlottingImportModal.tsx
+++ b/src/components/plotting/PlottingImportModal.tsx
@@ -1,0 +1,353 @@
+
+'use client';
+
+import { useState } from 'react';
+import { useDropzone } from 'react-dropzone';
+import Papa from 'papaparse';
+import * as XLSX from 'xlsx';
+import { FileSpreadsheet, Upload, X, Download, FileText } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Label } from '@/components/ui/label';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { cn } from '@/lib/utils';
+
+import { validatePlottingImport, savePlotting } from '@/lib/fetchers/plottingFetcher';
+import PlottingCSVPreview, { PlottingPreviewRow } from './PlottingCSVPreview';
+
+interface PlottingImportModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: () => void;
+  terms: string[];
+}
+
+// Extend row type to hold internal IDs
+type ExtendedPreviewRow = PlottingPreviewRow & { 
+    asprakId?: string; 
+    praktikumId?: string; 
+};
+
+export default function PlottingImportModal({
+  open,
+  onOpenChange,
+  onSuccess,
+  terms,
+}: PlottingImportModalProps) {
+  const [step, setStep] = useState<'upload' | 'preview'>('upload');
+  const [selectedTerm, setSelectedTerm] = useState<string>('');
+  const [error, setError] = useState<string | null>(null);
+  const [fileName, setFileName] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  
+  const [previewRows, setPreviewRows] = useState<ExtendedPreviewRow[]>([]);
+
+  // CSV Processing
+  const processCSV = (file: File) => {
+    setError(null);
+    setFileName(file.name);
+    setLoading(true);
+
+    Papa.parse(file, {
+      header: true,
+      skipEmptyLines: true,
+      complete: async (results: any) => {
+        const rawRows = results.data.map((row: any) => ({
+          kode_asprak: row.kode_asprak || '',
+          mk_singkat: row.mk_singkat || '',
+        })).filter((r: any) => r.kode_asprak && r.mk_singkat);
+
+        if (rawRows.length === 0) {
+          setError('CSV empty or missing columns (kode_asprak, mk_singkat)');
+          setLoading(false);
+          return;
+        }
+
+        // Validate via API
+        const res = await validatePlottingImport(rawRows, selectedTerm);
+        setLoading(false);
+
+        if (res.ok && res.data) {
+           const { validRows, ambiguousRows, invalidRows } = res.data;
+           
+           const mapped: ExtendedPreviewRow[] = [];
+           let idx = 0;
+
+           // Valid
+           validRows.forEach((r: any) => {
+               mapped.push({
+                   index: idx++,
+                   kode_asprak: r.original?.kode_asprak || '???',
+                   mk_singkat: r.original?.mk_singkat || '???',
+                   status: 'valid',
+                   selected: true,
+                   asprakId: r.asprak_id,
+                   praktikumId: r.praktikum_id
+               });
+           });
+
+           // Ambiguous
+           ambiguousRows.forEach(r => {
+               mapped.push({
+                   index: idx++,
+                   kode_asprak: r.original.kode_asprak,
+                   mk_singkat: r.original.mk_singkat,
+                   status: 'ambiguous',
+                   message: r.reason,
+                   candidates: r.candidates,
+                   selected: true, // Selected by default, but no candidates selected yet
+                   selectedCandidateIds: [], // Empty initially
+                   praktikumId: r.praktikum_id
+               });
+           });
+
+           // Invalid
+           invalidRows.forEach(r => {
+               mapped.push({
+                   index: idx++,
+                   kode_asprak: r.original.kode_asprak,
+                   mk_singkat: r.original.mk_singkat,
+                   status: 'invalid',
+                   message: r.reason,
+                   selected: false
+               });
+           });
+           
+           setPreviewRows(mapped);
+           setStep('preview');
+        } else {
+           setError(res.error || 'Validation failed');
+        }
+      },
+      error: (e) => {
+          setError(`CSV Error: ${e.message}`);
+          setLoading(false);
+      }
+    });
+  };
+  
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+      accept: { 'text/csv': ['.csv'] },
+      maxFiles: 1,
+      disabled: !selectedTerm,
+      onDrop: (files) => files[0] && processCSV(files[0])
+  });
+
+  const handleDownloadTemplate = (format: 'csv' | 'xlsx') => {
+    const data = [
+      { kode_asprak: 'ARS', mk_singkat: 'PBO' },
+      { kode_asprak: 'ZZA', mk_singkat: 'STRUKDAT' },
+    ];
+
+    if (format === 'csv') {
+      const csv = Papa.unparse(data);
+      const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.setAttribute('download', 'template_plotting.csv');
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    } else {
+      const ws = XLSX.utils.json_to_sheet(data);
+      const wb = XLSX.utils.book_new();
+      XLSX.utils.book_append_sheet(wb, ws, 'Template');
+      XLSX.writeFile(wb, 'template_plotting.xlsx');
+    }
+  };
+
+  const handleResolve = (index: number, candidateId: string) => {
+      setPreviewRows(prev => {
+          const update = [...prev];
+          const row = { ...update[index] };
+          
+          const currentIds = row.selectedCandidateIds || [];
+          if (currentIds.includes(candidateId)) {
+              row.selectedCandidateIds = currentIds.filter(id => id !== candidateId);
+          } else {
+              row.selectedCandidateIds = [...currentIds, candidateId];
+          }
+          
+          update[index] = row;
+          return update;
+      });
+  };
+
+  const handleConfirm = async () => {
+      const payload: {asprak_id: string, praktikum_id: string}[] = [];
+      
+      previewRows.forEach(row => {
+          if (!row.selected) return;
+          if (row.status === 'invalid') return;
+          
+          // Valid rows
+          if (row.status === 'valid' && row.asprakId && row.praktikumId) {
+              payload.push({ asprak_id: row.asprakId, praktikum_id: row.praktikumId });
+          }
+          
+          // Ambiguous rows (resolved via multiple selection)
+          else if (row.status === 'ambiguous' && row.selectedCandidateIds && row.praktikumId) {
+              row.selectedCandidateIds.forEach(id => {
+                  payload.push({ asprak_id: id, praktikum_id: row.praktikumId! });
+              });
+          }
+      });
+      
+      if (payload.length === 0) {
+          toast.warning("No assignments to save");
+          return;
+      }
+
+      setLoading(true);
+      const res = await savePlotting(payload);
+      setLoading(false);
+      
+      if (res.ok) {
+          toast.success(`Saved ${payload.length} assignments successfully!`);
+          onSuccess();
+          handleClose();
+      } else {
+          toast.error(res.error);
+      }
+  };
+  
+  const handleClose = () => {
+      setStep('upload');
+      setPreviewRows([]);
+      setFileName(null);
+      setError(null);
+      onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+       <DialogContent className={cn(
+          "flex max-h-[min(800px,90vh)] flex-col gap-0 p-0",
+          step === 'preview' ? "sm:max-w-4xl" : "sm:max-w-lg"
+       )}>
+          <DialogHeader className="contents space-y-0 text-left">
+             <DialogTitle className="border-b px-6 py-4 flex items-center gap-2">
+                <Upload size={18}/> Import CSV Plotting
+             </DialogTitle>
+          </DialogHeader>
+
+          <ScrollArea className="flex max-h-full flex-col overflow-hidden">
+             <div className="px-6 py-5">
+                 {error && (
+                    <Alert className="mb-4 text-destructive border-destructive/50">
+                        <AlertDescription className="flex gap-2">
+                             <X size={16} className="mt-0.5"/> {error}
+                        </AlertDescription>
+                    </Alert>
+                 )}
+
+                 {step === 'upload' && (
+                     <div className="space-y-6">
+                         <div className="space-y-2">
+                             <Label>Tahun Ajaran Penugasan</Label>
+                             <Select value={selectedTerm} onValueChange={setSelectedTerm}>
+                                 <SelectTrigger><SelectValue placeholder="Pilih Term" /></SelectTrigger>
+                                 <SelectContent>
+                                     {terms.map(t => <SelectItem key={t} value={t}>{t}</SelectItem>)}
+                                 </SelectContent>
+                             </Select>
+                             <p className="text-xs text-muted-foreground">Isi term terlebih dahulu sebelum upload CSV.</p>
+                         </div>
+
+                         <div {...getRootProps()} 
+                            className={cn(
+                                "border-2 border-dashed rounded-lg p-10 text-center transition-all",
+                                !selectedTerm ? "border-muted bg-muted/20 opacity-50 cursor-not-allowed" : 
+                                isDragActive ? "border-primary bg-primary/5" : "hover:border-primary/50 cursor-pointer"
+                            )}
+                         >
+                             <input {...getInputProps()} />
+                             <FileSpreadsheet size={40} className="mx-auto mb-3 text-muted-foreground"/>
+                             {!selectedTerm ? (
+                                 <p className="font-medium text-muted-foreground">Pilih Term dulu</p>
+                             ) : isDragActive ? (
+                                 <p className="text-primary font-semibold">Drop file di sini...</p>
+                             ) : (
+                                 <div className="space-y-1">
+                                    <p className="font-medium">Drag & drop CSV Asprak</p>
+                                    <p className="text-xs text-muted-foreground">Format: kode_asprak, mk_singkat</p>
+                                 </div>
+                             )}
+                         </div>
+
+                         <div className="bg-muted/30 p-4 rounded-lg border border-border/50">
+                            <p className="text-xs text-muted-foreground mb-2 font-medium">Format Kolom:</p>
+                            <div className="flex flex-wrap gap-2 mb-1">
+                              {['kode_asprak', 'mk_singkat'].map((col) => (
+                                <span key={col} className="text-[10px] bg-background border px-1.5 py-0.5 rounded font-mono text-muted-foreground">
+                                  {col}
+                                </span>
+                              ))}
+                            </div>
+                            
+                            <div className="flex items-center gap-3 pt-2 border-t border-border/50">
+                              <span className="text-xs text-muted-foreground flex items-center gap-1.5">
+                                <Download size={12} />
+                                Download Template:
+                              </span>
+                              <div className="flex gap-2">
+                                <Button 
+                                  variant="outline" 
+                                  size="sm" 
+                                  className="h-7 text-xs px-2 gap-1.5 bg-background"
+                                  onClick={() => handleDownloadTemplate('csv')}
+                                >
+                                  <FileText size={12} className="text-sky-500" />
+                                  CSV
+                                </Button>
+                                <Button 
+                                  variant="outline" 
+                                  size="sm" 
+                                  className="h-7 text-xs px-2 gap-1.5 bg-background"
+                                  onClick={() => handleDownloadTemplate('xlsx')}
+                                >
+                                  <FileSpreadsheet size={12} className="text-emerald-500" />
+                                  XLSX
+                                </Button>
+                              </div>
+                            </div>
+                          </div>
+                     </div>
+                 )}
+
+                 {step === 'preview' && (
+                     <PlottingCSVPreview
+                        rows={previewRows}
+                        term={selectedTerm}
+                        onConfirm={handleConfirm}
+                        onBack={() => { setStep('upload'); setPreviewRows([]); }}
+                        onResolve={handleResolve}
+                        onToggleSelect={(idx) => setPreviewRows(p => {
+                            const u = [...p]; u[idx].selected = !u[idx].selected; return u;
+                        })}
+                        onToggleAll={(checked) => setPreviewRows(p => p.map(r => r.status==='invalid' ? r : {...r, selected: checked}))}
+                        loading={loading}
+                     />
+                 )}
+             </div>
+          </ScrollArea>
+       </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/plotting/PlottingManualModal.tsx
+++ b/src/components/plotting/PlottingManualModal.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Label } from '@/components/ui/label';
+import { Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+import { fetchAllAsprak } from '@/lib/fetchers/asprakFetcher';
+import { fetchPraktikumByTerm } from '@/lib/fetchers/praktikumFetcher';
+import { savePlotting } from '@/lib/fetchers/plottingFetcher'; // Reuse save
+import { Asprak, Praktikum } from '@/types/database';
+
+interface PlottingManualModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: () => void;
+  terms: string[];
+}
+
+export default function PlottingManualModal({
+  open,
+  onOpenChange,
+  onSuccess,
+  terms,
+}: PlottingManualModalProps) {
+  const [loading, setLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  
+  const [selectedTerm, setSelectedTerm] = useState('');
+  const [selectedAsprak, setSelectedAsprak] = useState('');
+  const [selectedPraktikum, setSelectedPraktikum] = useState('');
+  
+  const [aspraks, setAspraks] = useState<Asprak[]>([]);
+  const [praktikums, setPraktikums] = useState<Praktikum[]>([]);
+
+  // Fetch Aspraks once
+  useEffect(() => {
+    if (open) {
+        setLoading(true);
+        fetchAllAsprak().then(res => {
+            if (res.ok && res.data) setAspraks(res.data);
+            setLoading(false);
+        });
+    }
+  }, [open]);
+
+  // Fetch Praktikums when term changes
+  useEffect(() => {
+      if (selectedTerm) {
+          fetchPraktikumByTerm(selectedTerm).then(res => {
+              if (res.ok && res.data) setPraktikums(res.data);
+              else setPraktikums([]);
+          });
+      } else {
+          setPraktikums([]);
+      }
+      setSelectedPraktikum('');
+  }, [selectedTerm]);
+
+  const handleSubmit = async () => {
+      if (!selectedAsprak || !selectedPraktikum) {
+          toast.error("Please select Asprak and Course");
+          return;
+      }
+      
+      setSubmitting(true);
+      const result = await savePlotting([{
+          asprak_id: selectedAsprak,
+          praktikum_id: selectedPraktikum
+      }]);
+      
+      setSubmitting(false);
+      
+      if (result.ok) {
+          toast.success("Assignment saved successfully");
+          onSuccess();
+          onOpenChange(false);
+          // Reset
+          setSelectedAsprak('');
+          setSelectedPraktikum('');
+      } else {
+          toast.error(`Failed to save: ${result.error}`);
+      }
+  };
+
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[min(700px,85vh)] flex-col gap-0 p-0 sm:max-w-lg">
+        <DialogHeader className="contents space-y-0 text-left">
+          <DialogTitle className="border-b px-6 py-4">Input Manual Plotting</DialogTitle>
+        </DialogHeader>
+        
+        <ScrollArea className="flex-1 overflow-y-auto">
+            <div className="px-6 py-6 grid gap-6">
+                {/* Term */}
+                <div className="grid gap-2">
+                    <Label>Term</Label>
+                    <Select value={selectedTerm} onValueChange={setSelectedTerm}>
+                        <SelectTrigger><SelectValue placeholder="Select Term" /></SelectTrigger>
+                        <SelectContent>
+                            {terms.map(t => <SelectItem key={t} value={t}>{t}</SelectItem>)}
+                        </SelectContent>
+                    </Select>
+                </div>
+                
+                {/* Praktikum (Dependent on Term) */}
+                <div className="grid gap-2">
+                    <Label>Course (Praktikum)</Label>
+                    <Select value={selectedPraktikum} onValueChange={setSelectedPraktikum} disabled={!selectedTerm}>
+                        <SelectTrigger><SelectValue placeholder="Select Course" /></SelectTrigger>
+                        <SelectContent>
+                            {praktikums.map(p => <SelectItem key={p.id} value={p.id}>{p.nama}</SelectItem>)}
+                        </SelectContent>
+                    </Select>
+                </div>
+                
+                {/* Asprak */}
+                <div className="grid gap-2">
+                    <Label>Asprak</Label>
+                    {loading ? (
+                        <div className="text-sm text-muted-foreground flex items-center"><Loader2 className="mr-2 h-4 w-4 animate-spin"/> Loading aspraks...</div>
+                    ) : (
+                        <Select value={selectedAsprak} onValueChange={setSelectedAsprak}>
+                            <SelectTrigger><SelectValue placeholder="Select Asprak" /></SelectTrigger>
+                            <SelectContent className="max-h-[200px]">
+                                {aspraks.map(a => (
+                                    <SelectItem key={a.id} value={a.id}>
+                                        {a.nama_lengkap} ({a.kode})
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    )}
+                </div>
+            </div>
+        </ScrollArea>
+
+        <div className="border-t px-6 py-4 flex justify-end gap-2">
+            <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>Cancel</Button>
+            <Button onClick={handleSubmit} disabled={submitting || !selectedAsprak || !selectedPraktikum}>
+                {submitting && <Loader2 className="mr-2 h-4 w-4 animate-spin"/>}
+                Assign
+            </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+
+}

--- a/src/components/plotting/PlottingTable.tsx
+++ b/src/components/plotting/PlottingTable.tsx
@@ -1,0 +1,195 @@
+
+'use client';
+
+import { useMemo } from 'react';
+import {
+  useReactTable,
+  getCoreRowModel,
+  getPaginationRowModel,
+  flexRender,
+  ColumnDef,
+} from '@tanstack/react-table';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { AsprakPlottingData } from '@/lib/fetchers/asprakFetcher';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+interface PlottingTableProps {
+  data: AsprakPlottingData[];
+  loading: boolean;
+  term?: string;
+}
+
+export default function PlottingTable({
+  data,
+  loading,
+  term,
+}: PlottingTableProps) {
+  const columns = useMemo<ColumnDef<AsprakPlottingData>[]>(
+    () => [
+      {
+        accessorKey: 'nim',
+        header: 'NIM',
+        cell: ({ row }) => <span className="font-mono text-xs text-muted-foreground">{row.original.nim}</span>
+      },
+      {
+        accessorKey: 'kode',
+        header: 'Kode',
+        cell: ({ row }) => <Badge variant="outline" className="font-mono">{row.original.kode}</Badge>,
+      },
+      {
+        accessorKey: 'nama_lengkap',
+        header: 'Nama Lengkap',
+        cell: ({ row }) => <span className="font-medium">{row.original.nama_lengkap}</span>
+      },
+      {
+        id: 'assignments',
+        header: 'Assigned Courses',
+        cell: ({ row }) => (
+          <div className="flex flex-wrap gap-2">
+            {row.original.assignments.length > 0 ? (
+              row.original.assignments.map((a, i) => (
+                <Badge key={`${a.id}-${i}`} variant="secondary" className="hover:bg-primary/20 transition-colors cursor-default">
+                  {a.nama}
+                  {(term === 'all' || !term) && (
+                    <span className="ml-1 text-[10px] opacity-60 font-mono">({a.tahun_ajaran})</span>
+                  )}
+                </Badge>
+              ))
+            ) : (
+              <span className="text-muted-foreground text-sm italic opacity-50">-</span>
+            )}
+          </div>
+        ),
+      },
+    ],
+    [term]
+  );
+
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    initialState: {
+      pagination: {
+        pageSize: 10,
+      },
+    },
+  });
+
+  if (loading) {
+    return (
+      <div className="rounded-md border p-8 text-center text-muted-foreground">
+        Loading data...
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-md border bg-background">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <TableHead key={header.id}>
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(header.column.columnDef.header, header.getContext())}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow key={row.id}>
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={columns.length} className="h-24 text-center">
+                  No results.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      <div className="flex items-center justify-between px-2">
+        <div className="flex-1 text-sm text-muted-foreground">
+          {table.getFilteredRowModel().rows.length} records found.
+        </div>
+        <div className="flex items-center space-x-6 lg:space-x-8">
+          <div className="flex items-center space-x-2">
+            <p className="text-sm font-medium">Rows per page</p>
+            <Select
+              value={`${table.getState().pagination.pageSize}`}
+              onValueChange={(value) => {
+                table.setPageSize(Number(value));
+              }}
+            >
+              <SelectTrigger className="h-8 w-[70px]">
+                <SelectValue placeholder={table.getState().pagination.pageSize} />
+              </SelectTrigger>
+              <SelectContent side="top">
+                {[10, 20, 30, 50, 100].map((pageSize) => (
+                  <SelectItem key={pageSize} value={`${pageSize}`}>
+                    {pageSize}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex w-[100px] items-center justify-center text-sm font-medium">
+            Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
+          </div>
+          <div className="flex items-center space-x-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => table.previousPage()}
+              disabled={!table.getCanPreviousPage()}
+            >
+              <ChevronLeft className="h-4 w-4" />
+              Previous
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => table.nextPage()}
+              disabled={!table.getCanNextPage()}
+            >
+              Next
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/fetchers/asprakFetcher.ts
+++ b/src/lib/fetchers/asprakFetcher.ts
@@ -25,6 +25,34 @@ export interface AsprakAssignment {
   };
 }
 
+export interface AsprakPlottingData extends Asprak {
+    assignments: {
+        id: string; // Praktikum ID
+        nama: string;
+        tahun_ajaran: string;
+    }[];
+}
+
+export async function fetchPlottingData(term?: string): Promise<ServiceResult<AsprakPlottingData[]>> {
+  try {
+    const url = new URL('/api/asprak', window.location.origin);
+    url.searchParams.append('action', 'plotting');
+    if (term) url.searchParams.append('term', term);
+    
+    const res = await fetch(url.toString());
+    const json = await res.json();
+
+    if (!res.ok) {
+      return { ok: false, error: json.error };
+    }
+
+    return { ok: true, data: json.data };
+  } catch (e: any) {
+    logger.error('Error fetching plotting data:', e);
+    return { ok: false, error: e.message };
+  }
+}
+
 export async function fetchAllAsprak(term?: string): Promise<ServiceResult<Asprak[]>> {
   try {
     const url = term ? `/api/asprak?term=${encodeURIComponent(term)}` : '/api/asprak';

--- a/src/lib/fetchers/plottingFetcher.ts
+++ b/src/lib/fetchers/plottingFetcher.ts
@@ -1,0 +1,58 @@
+
+import { logger } from '@/lib/logger';
+import { ServiceResult } from '@/types/api';
+
+export interface ValidatePlottingRow {
+  kode_asprak: string;
+  mk_singkat: string;
+  selected_asprak_id?: string;
+}
+
+export interface ValidationResult {
+  validRows: { asprak_id: string; praktikum_id: string; original: ValidatePlottingRow }[];
+  ambiguousRows: { 
+     original: ValidatePlottingRow; 
+     candidates: { id: string; nama_lengkap: string; nim: string; angkatan: number }[];
+     reason: string;
+     praktikum_id: string;
+  }[];
+  invalidRows: { original: ValidatePlottingRow; reason: string }[];
+}
+
+
+export async function validatePlottingImport(
+  rows: ValidatePlottingRow[], 
+  term: string
+): Promise<ServiceResult<ValidationResult>> {
+  try {
+    const res = await fetch('/api/plotting', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'validate-import', rows, term }),
+    });
+    const json = await res.json();
+    if (!res.ok) return { ok: false, error: json.error };
+    return { ok: true, data: json };
+  } catch (e: any) {
+    logger.error('Error validating plotting import:', e);
+    return { ok: false, error: e.message };
+  }
+}
+
+export async function savePlotting(
+  assignments: { asprak_id: string; praktikum_id: string }[]
+): Promise<ServiceResult<void>> {
+  try {
+    const res = await fetch('/api/plotting', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'save-plotting', assignments }),
+    });
+    const json = await res.json();
+    if (!res.ok) return { ok: false, error: json.error };
+    return { ok: true, data: undefined };
+  } catch (e: any) {
+    logger.error('Error saving plotting:', e);
+    return { ok: false, error: e.message };
+  }
+}

--- a/src/services/plottingService.ts
+++ b/src/services/plottingService.ts
@@ -1,0 +1,214 @@
+
+import { supabase } from './supabase';
+import { logger } from '@/lib/logger';
+
+export interface PlottingItem {
+  id: number; // Asprak_Praktikum ID
+  asprak: {
+    id: string;
+    kode: string;
+    nama_lengkap: string;
+    nim: string;
+  };
+  praktikum: {
+    id: string;
+    nama: string;
+    tahun_ajaran: string;
+  };
+}
+
+export interface PlottingListResult {
+  data: PlottingItem[];
+  total: number;
+}
+
+export async function getPlottingList(
+  page: number,
+  limit: number,
+  term?: string,
+  praktikumId?: string
+): Promise<PlottingListResult> {
+  const from = (page - 1) * limit;
+  const to = from + limit - 1;
+
+  let query = supabase
+    .from('Asprak_Praktikum')
+    .select(`
+      id,
+      asprak:Asprak!inner (
+        id, kode, nama_lengkap, nim
+      ),
+      praktikum:Praktikum!inner (
+        id, nama, tahun_ajaran
+      )
+    `, { count: 'exact' });
+
+  // Apply filters
+  if (term && term !== 'all') {
+    query = query.eq('praktikum.tahun_ajaran', term);
+  }
+
+  if (praktikumId && praktikumId !== 'all') {
+    query = query.eq('id_praktikum', praktikumId);
+  }
+  
+  // Sort by Asprak Code then Praktikum Name
+  // Note: Sorting on joined columns can be tricky with Supabase JS client depending on version.
+  // Usually we sort on main table or joined table with specific syntax.
+  // For now let's just paginate. Sorting might be default or need special handling.
+  
+  query = query.range(from, to);
+
+  const { data, count, error } = await query;
+
+  if (error) {
+    logger.error('Error fetching plotting list:', error);
+    throw new Error(error.message);
+  }
+
+  return {
+    data: (data || []) as unknown as PlottingItem[],
+    total: count || 0,
+  };
+}
+
+
+export interface ValidatePlottingRow {
+  kode_asprak: string;
+  mk_singkat: string;
+  selected_asprak_id?: string; // If user resolves ambiguity
+}
+
+export interface ValidationResult {
+  validRows: { asprak_id: string; praktikum_id: string; original: ValidatePlottingRow }[];
+  ambiguousRows: { 
+     original: ValidatePlottingRow; 
+     candidates: { id: string; nama_lengkap: string; nim: string; angkatan: number }[];
+     reason: string;
+     praktikum_id: string;
+  }[];
+  invalidRows: { original: ValidatePlottingRow; reason: string }[];
+}
+
+
+export async function validatePlottingImport(
+  rows: ValidatePlottingRow[],
+  term: string
+): Promise<ValidationResult> {
+  
+  // 1. Fetch ALL Aspraks and Praktikums for lookup to minimize queries
+  // Or fetch in batches. If rows are huge (1000+), fetching all codes might be better.
+  // Aspraks: We need to map code -> ID(s).
+  
+  const { data: allAspraks } = await supabase
+    .from('Asprak')
+    .select('id, kode, nama_lengkap, nim, angkatan');
+    
+  const asprakMap = new Map<string, typeof allAspraks>();
+  allAspraks?.forEach(a => {
+      const existing = asprakMap.get(a.kode) || [];
+      existing.push(a);
+      asprakMap.set(a.kode, existing);
+  });
+
+  // Praktikums: Map name -> ID for the SPECIFIED term.
+  const { data: termPraktikums } = await supabase
+    .from('Praktikum')
+    .select('id, nama')
+    .eq('tahun_ajaran', term);
+    
+  const praktikumMap = new Map<string, string>(); // name -> id
+  termPraktikums?.forEach(p => {
+      praktikumMap.set(p.nama.toUpperCase(), p.id); // keys uppercase
+  });
+
+  const result: ValidationResult = {
+    validRows: [],
+    ambiguousRows: [],
+    invalidRows: []
+  };
+
+  for (const row of rows) {
+      const code = row.kode_asprak.trim();
+      const mkName = row.mk_singkat.trim().toUpperCase();
+      
+      // Check Praktikum
+      const praktikumId = praktikumMap.get(mkName);
+      if (!praktikumId) {
+          result.invalidRows.push({ original: row, reason: `Praktikum '${mkName}' not found in term ${term}` });
+          continue;
+      }
+      
+      // Check Asprak
+      // If user provided selected_asprak_id (manual resolution), valid.
+      if (row.selected_asprak_id) {
+           result.validRows.push({ 
+               asprak_id: row.selected_asprak_id, 
+               praktikum_id: praktikumId,
+               original: row 
+           });
+           continue;
+      }
+      
+      const candidates = asprakMap.get(code); // Returns array
+      
+      if (!candidates || candidates.length === 0) {
+          result.invalidRows.push({ original: row, reason: `Asprak code '${code}' not found` });
+      } else if (candidates.length === 1) {
+          result.validRows.push({ 
+              asprak_id: candidates[0].id, 
+              praktikum_id: praktikumId,
+              original: row 
+          });
+      } else {
+          // Ambiguous
+          result.ambiguousRows.push({ 
+              original: row, 
+              candidates: candidates,
+              reason: `Multiple aspraks found with code '${code}'`,
+              praktikum_id: praktikumId
+          });
+      }
+  }
+
+  return result;
+}
+
+export async function savePlotting(assignments: { asprak_id: string; praktikum_id: string }[]) {
+    // Insert ignoring duplicates? Or fail?
+    // Supabase insert has `ignoreDuplicates` option but mostly for primary keys.
+    // If unique constraint on (asprak_id, praktikum_id) exists, we catch error or ignore.
+    
+    // We'll process one by one or batch with error handling?
+    // Batch is faster.
+    
+    // Transform to DB rows
+    const dbRows = assignments.map(a => ({
+        id_asprak: a.asprak_id,
+        id_praktikum: a.praktikum_id
+    }));
+    
+    // We must handle duplicates gracefully.
+    // If we use `upsert`... there is no 'update' needed, just 'do nothing if exists'.
+    // `upsert` with `onConflict` works.
+    // Assuming unique constraint `asprak_praktikum_id_asprak_id_praktikum_key` or similar exists?
+    // Or just simple `id_asprak, id_praktikum`.
+    
+    // Let's try upsert + ignore duplicates.
+    // Or select existing first?
+    // For large batches, select existing is expensive.
+    
+    const { error } = await supabase
+        .from('Asprak_Praktikum')
+        .upsert(dbRows, { onConflict: 'id_asprak, id_praktikum', ignoreDuplicates: true });
+        
+    if (error) {
+        logger.error('Error saving plotting assignments:', error);
+        throw new Error(error.message);
+    }
+}
+
+export async function deletePlotting(id: number) {
+    const { error } = await supabase.from('Asprak_Praktikum').delete().eq('id', id);
+    if (error) throw new Error(error.message);
+}


### PR DESCRIPTION
… download

- Update [PlottingImportModal](cci:1://file:///f:/projectiflab/manajemenasprak/src/components/plotting/PlottingImportModal.tsx:45:0-352:1) UI to match Asprak Data page (ScrollArea, Drag & Drop style).
- Add CSV and XLSX template download functionality for plotting import.
- Change ambiguity resolution UI to use checkboxes, allowing multiple candidate selection for a single row.
- Support creating multiple assignments from ambiguous rows based on selection.
- Refactor [PlottingManualModal](cci:1://file:///f:/projectiflab/manajemenasprak/src/components/plotting/PlottingManualModal.tsx:34:0-164:1) layout for better UI consistency.
- Fix button order and styling on [PlottingPage](cci:1://file:///f:/projectiflab/manajemenasprak/src/app/plotting/page.tsx:15:0-140:1).
- Improve validation service to return original row data for better preview accuracy.