### PR TITLE
fix : Allow updating asprak code when editing assignments

### DIFF
--- a/src/app/(dashboard)/asprak/page.tsx
+++ b/src/app/(dashboard)/asprak/page.tsx
@@ -100,7 +100,6 @@ function AsprakPageContent() {
     refreshCodesAndNims();
   }, []);
 
-
   const handleFormSubmit = async (data: UpsertAsprakInput) => {
     const result = await upsert(data);
 
@@ -112,7 +111,6 @@ function AsprakPageContent() {
     fetchAsprak();
     refreshCodesAndNims();
   };
-
 
   const handleCSVImport = async (
     rows: { nim: string; nama_lengkap: string; kode: string; angkatan: number }[],
@@ -187,11 +185,17 @@ function AsprakPageContent() {
     setShowEditModal(true);
   };
 
-  const handleSaveEdit = async (praktikumIds: string[]) => {
+  const handleSaveEdit = async (praktikumIds: string[], newKode: string) => {
     if (!editTarget) return;
 
     // Use 'all' to indicate global update
-    const result = await updateAssignments(editTarget.asprak.id, 'all', praktikumIds);
+    const result = await updateAssignments(
+      editTarget.asprak.id,
+      'all',
+      praktikumIds,
+      newKode,
+      editTarget.asprak.nim
+    );
 
     if (result.ok) {
       toast.success('Penugasan berhasil diperbarui');

--- a/src/app/api/asprak/route.ts
+++ b/src/app/api/asprak/route.ts
@@ -67,17 +67,24 @@ export async function POST(req: Request) {
         return NextResponse.json({ ok: true, data: result });
       }
       case 'update-assignments': {
-        const { asprakId, term, praktikumIds } = body;
-        await asprakService.updateAsprakAssignments(asprakId, term, praktikumIds, supabase);
+        const { asprakId, term, praktikumIds, newKode, nim } = body;
+        await asprakService.updateAsprakAssignments(
+          asprakId,
+          term,
+          praktikumIds,
+          supabase,
+          newKode,
+          nim
+        );
         return NextResponse.json({ ok: true, data: null });
       }
       case 'check-nim': {
-          const exists = await asprakService.checkNimExists(body.nim, supabase);
-          return NextResponse.json({ ok: true, data: { exists } });
+        const exists = await asprakService.checkNimExists(body.nim, supabase);
+        return NextResponse.json({ ok: true, data: { exists } });
       }
       case 'generate-code': {
-          const result = await asprakService.generateUniqueCode(body.name, supabase);
-          return NextResponse.json({ ok: true, data: result });
+        const result = await asprakService.generateUniqueCode(body.name, supabase);
+        return NextResponse.json({ ok: true, data: result });
       }
       default:
         return NextResponse.json({ ok: false, error: 'Invalid action' }, { status: 400 });
@@ -111,4 +118,3 @@ export async function DELETE(req: Request) {
     return NextResponse.json({ ok: false, error: e.message }, { status: 500 });
   }
 }
-

--- a/src/components/asprak/AsprakEditModal.tsx
+++ b/src/components/asprak/AsprakEditModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
 import {
   Dialog,
   DialogContent,
@@ -17,7 +18,7 @@ interface AsprakEditModalProps {
   asprak: Asprak;
   term: string; // The term being edited or 'all'
   assignments: string[]; // List of praktikum IDs currently assigned
-  onSave: (praktikumIds: string[]) => Promise<void>;
+  onSave: (praktikumIds: string[], newKode: string) => Promise<void>;
   onClose: () => void;
   open: boolean;
 }
@@ -32,6 +33,8 @@ export default function AsprakEditModal({
   const { getPraktikumByTerm, loading: loadingPraktikum } = usePraktikum();
   const [availablePraktikums, setAvailablePraktikums] = useState<Praktikum[]>([]);
   const [selectedPraktikumIds, setSelectedPraktikumIds] = useState<string[]>([]);
+  const [newKode, setNewKode] = useState<string>(asprak.kode);
+  const [kodeError, setKodeError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
@@ -43,12 +46,19 @@ export default function AsprakEditModal({
       // Initialize selection
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setSelectedPraktikumIds(assignments);
+      setNewKode(asprak.kode);
+      setKodeError(null);
     }
-  }, [open, getPraktikumByTerm, assignments]);
+  }, [open, getPraktikumByTerm, assignments, asprak.kode]);
 
   const handleSave = async () => {
+    if (newKode.length !== 3) {
+      setKodeError('Kode Asisten harus persis 3 huruf');
+      return;
+    }
+
     setSaving(true);
-    await onSave(selectedPraktikumIds);
+    await onSave(selectedPraktikumIds, newKode.toUpperCase());
     setSaving(false);
     onClose();
   };
@@ -91,8 +101,23 @@ export default function AsprakEditModal({
               <div className="font-medium">{asprak.nim}</div>
             </div>
             <div>
-              <Label className="text-muted-foreground text-xs">Kode</Label>
-              <div className="font-medium font-mono">{asprak.kode}</div>
+              <Label htmlFor="kode" className="text-muted-foreground text-xs">
+                Kode
+              </Label>
+              <Input
+                id="kode"
+                value={newKode}
+                onChange={(e) => {
+                  setNewKode(e.target.value.toUpperCase().slice(0, 3));
+                  setKodeError(null);
+                }}
+                className={`font-mono uppercase transition-colors h-8 ${
+                  kodeError ? 'border-red-500 focus-visible:ring-red-500' : ''
+                }`}
+                placeholder="ABC"
+                maxLength={3}
+              />
+              {kodeError && <p className="text-red-500 text-xs mt-1">{kodeError}</p>}
             </div>
           </div>
           <div>

--- a/src/lib/fetchers/asprakFetcher.ts
+++ b/src/lib/fetchers/asprakFetcher.ts
@@ -98,13 +98,22 @@ export async function upsertAsprak(input: UpsertAsprakInput): Promise<ServiceRes
 export async function updateAssignments(
   asprakId: number | string,
   term: string,
-  praktikumIds: string[]
+  praktikumIds: string[],
+  newKode?: string,
+  nim?: string
 ): Promise<ServiceResult<void>> {
   try {
     const res = await fetch('/api/asprak', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ action: 'update-assignments', asprakId, term, praktikumIds }),
+      body: JSON.stringify({
+        action: 'update-assignments',
+        asprakId,
+        term,
+        praktikumIds,
+        newKode,
+        nim,
+      }),
     });
 
     const json = await res.json();
@@ -265,4 +274,3 @@ export async function generateCode(
     return { ok: false, error: e.message };
   }
 }
-

--- a/src/services/plottingService.ts
+++ b/src/services/plottingService.ts
@@ -37,9 +37,8 @@ export async function getPlottingList(
   const from = (page - 1) * limit;
   const to = from + limit - 1;
 
-  let query = supabase
-    .from('asprak_praktikum')
-    .select(`
+  let query = supabase.from('asprak_praktikum').select(
+    `
       id,
       asprak:asprak!inner (
         id, kode, nama_lengkap, nim
@@ -47,7 +46,9 @@ export async function getPlottingList(
       praktikum:praktikum!inner (
         id, nama, tahun_ajaran
       )
-    `, { count: 'exact' });
+    `,
+    { count: 'exact' }
+  );
 
   // Apply filters
   if (term && term !== 'all') {
@@ -57,12 +58,12 @@ export async function getPlottingList(
   if (praktikumId && praktikumId !== 'all') {
     query = query.eq('id_praktikum', praktikumId);
   }
-  
+
   // Sort by Asprak Code then Praktikum Name
   // Note: Sorting on joined columns can be tricky with Supabase JS client depending on version.
   // Usually we sort on main table or joined table with specific syntax.
   // For now let's just paginate. Sorting might be default or need special handling.
-  
+
   query = query.range(from, to);
 
   const { data, count, error } = await query;
@@ -78,7 +79,6 @@ export async function getPlottingList(
   };
 }
 
-
 export interface ValidatePlottingRow {
   kode_asprak: string;
   mk_singkat: string;
@@ -87,15 +87,14 @@ export interface ValidatePlottingRow {
 
 export interface ValidationResult {
   validRows: { asprak_id: string; praktikum_id: string; original: ValidatePlottingRow }[];
-  ambiguousRows: { 
-     original: ValidatePlottingRow; 
-     candidates: { id: string; nama_lengkap: string; nim: string; angkatan: number }[];
-     reason: string;
-     praktikum_id: string;
+  ambiguousRows: {
+    original: ValidatePlottingRow;
+    candidates: { id: string; nama_lengkap: string; nim: string; angkatan: number }[];
+    reason: string;
+    praktikum_id: string;
   }[];
   invalidRows: { original: ValidatePlottingRow; reason: string }[];
 }
-
 
 export async function validatePlottingImport(
   rows: ValidatePlottingRow[],
@@ -103,20 +102,20 @@ export async function validatePlottingImport(
   supabaseClient?: SupabaseClient
 ): Promise<ValidationResult> {
   const supabase = supabaseClient || globalAdmin;
-  
+
   // 1. Fetch ALL Aspraks and Praktikums for lookup to minimize queries
   // Or fetch in batches. If rows are huge (1000+), fetching all codes might be better.
   // Aspraks: We need to map code -> ID(s).
-  
+
   const { data: allAspraks } = await supabase
     .from('asprak')
     .select('id, kode, nama_lengkap, nim, angkatan');
-    
+
   const asprakMap = new Map<string, typeof allAspraks>();
-  allAspraks?.forEach(a => {
-      const existing = asprakMap.get(a.kode) || [];
-      existing.push(a);
-      asprakMap.set(a.kode, existing);
+  allAspraks?.forEach((a) => {
+    const existing = asprakMap.get(a.kode) || [];
+    existing.push(a);
+    asprakMap.set(a.kode, existing);
   });
 
   // Praktikums: Map name -> ID for the SPECIFIED term.
@@ -124,101 +123,118 @@ export async function validatePlottingImport(
     .from('praktikum')
     .select('id, nama')
     .eq('tahun_ajaran', term);
-    
+
   const praktikumMap = new Map<string, string>(); // name -> id
-  termPraktikums?.forEach(p => {
-      praktikumMap.set(p.nama.toUpperCase(), p.id); // keys uppercase
+  termPraktikums?.forEach((p) => {
+    praktikumMap.set(p.nama.toUpperCase(), p.id); // keys uppercase
   });
 
   const result: ValidationResult = {
     validRows: [],
     ambiguousRows: [],
-    invalidRows: []
+    invalidRows: [],
   };
 
   for (const row of rows) {
-      const code = row.kode_asprak.trim();
-      const mkName = row.mk_singkat.trim().toUpperCase();
-      
-      // Check Praktikum
-      const praktikumId = praktikumMap.get(mkName);
-      if (!praktikumId) {
-          result.invalidRows.push({ original: row, reason: `Praktikum '${mkName}' not found in term ${term}` });
-          continue;
-      }
-      
-      // Check Asprak
-      // If user provided selected_asprak_id (manual resolution), valid.
-      if (row.selected_asprak_id) {
-           result.validRows.push({ 
-               asprak_id: row.selected_asprak_id, 
-               praktikum_id: praktikumId,
-               original: row 
-           });
-           continue;
-      }
-      
-      const candidates = asprakMap.get(code); // Returns array
-      
-      if (!candidates || candidates.length === 0) {
-          result.invalidRows.push({ original: row, reason: `Asprak code '${code}' not found` });
-      } else if (candidates.length === 1) {
-          result.validRows.push({ 
-              asprak_id: candidates[0].id, 
-              praktikum_id: praktikumId,
-              original: row 
-          });
-      } else {
-          // Ambiguous
-          result.ambiguousRows.push({ 
-              original: row, 
-              candidates: candidates,
-              reason: `Multiple aspraks found with code '${code}'`,
-              praktikum_id: praktikumId
-          });
-      }
+    const code = row.kode_asprak.trim();
+    const mkName = row.mk_singkat.trim().toUpperCase();
+
+    // Check Praktikum
+    const praktikumId = praktikumMap.get(mkName);
+    if (!praktikumId) {
+      result.invalidRows.push({
+        original: row,
+        reason: `Praktikum '${mkName}' not found in term ${term}`,
+      });
+      continue;
+    }
+
+    // Check Asprak
+    // If user provided selected_asprak_id (manual resolution), valid.
+    if (row.selected_asprak_id) {
+      result.validRows.push({
+        asprak_id: row.selected_asprak_id,
+        praktikum_id: praktikumId,
+        original: row,
+      });
+      continue;
+    }
+
+    const candidates = asprakMap.get(code); // Returns array
+
+    if (!candidates || candidates.length === 0) {
+      result.invalidRows.push({ original: row, reason: `Asprak code '${code}' not found` });
+    } else if (candidates.length === 1) {
+      result.validRows.push({
+        asprak_id: candidates[0].id,
+        praktikum_id: praktikumId,
+        original: row,
+      });
+    } else {
+      // Ambiguous
+      result.ambiguousRows.push({
+        original: row,
+        candidates: candidates,
+        reason: `Multiple aspraks found with code '${code}'`,
+        praktikum_id: praktikumId,
+      });
+    }
   }
 
   return result;
 }
 
-export async function savePlotting(assignments: { asprak_id: string; praktikum_id: string }[], supabaseClient?: SupabaseClient) {
-    const supabase = supabaseClient || globalAdmin;
-    // Insert ignoring duplicates? Or fail?
-    // Supabase insert has `ignoreDuplicates` option but mostly for primary keys.
-    // If unique constraint on (asprak_id, praktikum_id) exists, we catch error or ignore.
-    
-    // We'll process one by one or batch with error handling?
-    // Batch is faster.
-    
-    // Transform to DB rows
-    const dbRows = assignments.map(a => ({
-        id_asprak: a.asprak_id,
-        id_praktikum: a.praktikum_id
-    }));
-    
-    // We must handle duplicates gracefully.
-    // If we use `upsert`... there is no 'update' needed, just 'do nothing if exists'.
-    // `upsert` with `onConflict` works.
-    // Assuming unique constraint `asprak_praktikum_id_asprak_id_praktikum_key` or similar exists?
-    // Or just simple `id_asprak, id_praktikum`.
-    
-    // Let's try upsert + ignore duplicates.
-    // Or select existing first?
-    // For large batches, select existing is expensive.
-    
-    const { error } = await supabase
-        .from('asprak_praktikum')
-        .upsert(dbRows, { onConflict: 'id_asprak, id_praktikum', ignoreDuplicates: true });
-        
+export async function savePlotting(
+  assignments: { asprak_id: string; praktikum_id: string }[],
+  supabaseClient?: SupabaseClient
+) {
+  const supabase = supabaseClient || globalAdmin;
+
+  if (!assignments || assignments.length === 0) return;
+
+  // Transform to DB rows and ensure uniqueness in the payload itself
+  const uniqueAssignments = new Map<string, { id_asprak: string; id_praktikum: string }>();
+  assignments.forEach((a) => {
+    uniqueAssignments.set(`${a.asprak_id}_${a.praktikum_id}`, {
+      id_asprak: a.asprak_id,
+      id_praktikum: a.praktikum_id,
+    });
+  });
+  const payloadRows = Array.from(uniqueAssignments.values());
+
+  // Fetch existing mappings to avoid duplicate insertions
+  const asprakIds = Array.from(new Set(payloadRows.map((row) => row.id_asprak)));
+
+  // Batch fetch existing assignments if necessary
+  const { data: existing, error: fetchError } = await supabase
+    .from('asprak_praktikum')
+    .select('id_asprak, id_praktikum')
+    .in('id_asprak', asprakIds);
+
+  if (fetchError) {
+    logger.error('Error fetching existing plotting assignments:', fetchError);
+    throw new Error(fetchError.message);
+  }
+
+  const existingSet = new Set((existing || []).map((e) => `${e.id_asprak}_${e.id_praktikum}`));
+
+  // Filter out rows that already exist in the database
+  const toInsert = payloadRows.filter(
+    (row) => !existingSet.has(`${row.id_asprak}_${row.id_praktikum}`)
+  );
+
+  if (toInsert.length > 0) {
+    const { error } = await supabase.from('asprak_praktikum').insert(toInsert);
+
     if (error) {
-        logger.error('Error saving plotting assignments:', error);
-        throw new Error(error.message);
+      logger.error('Error saving plotting assignments:', error);
+      throw new Error(error.message);
     }
+  }
 }
 
 export async function deletePlotting(id: number, supabaseClient?: SupabaseClient) {
-    const supabase = supabaseClient || globalAdmin;
-    const { error } = await supabase.from('asprak_praktikum').delete().eq('id', id);
-    if (error) throw new Error(error.message);
+  const supabase = supabaseClient || globalAdmin;
+  const { error } = await supabase.from('asprak_praktikum').delete().eq('id', id);
+  if (error) throw new Error(error.message);
 }


### PR DESCRIPTION
Add support for updating an asprak's kode during assignment edits. Frontend: AsprakEditModal now shows an editable kode input with validation and passes the newKode to the page handler; page passes newKode and nim into update call. Fetcher & API: updateAssignments payload now includes newKode and nim and the API route forwards them to the service. Service: updateAsprakAssignments handles newKode by checking conflicts, expiring existing inactive owners, and updating the asprak.kode in the DB (with error handling). Also includes refactors and fixes in plottingService: query formatting, validatePlottingImport cleanup, and savePlotting improved to deduplicate payloads, skip existing mappings, and insert only new assignments. Minor whitespace/formatting fixes across files.