### PR TITLE
fix : Preserve CSV-provided codes and improve headers

### DIFF
--- a/src/components/asprak/AsprakImportCSVModal.tsx
+++ b/src/components/asprak/AsprakImportCSVModal.tsx
@@ -98,7 +98,14 @@ export default function AsprakImportCSVModal({
       Papa.parse<RawCSVRow>(file, {
         header: true,
         skipEmptyLines: true,
-        transformHeader: (header: string) => header.trim().toLowerCase().replace(/\s+/g, '_'),
+        transformHeader: (header: string) => {
+          const h = header.trim().toLowerCase();
+          if (h.includes('nama')) return 'nama_lengkap';
+          if (h.includes('nim')) return 'nim';
+          if (h.includes('kode')) return 'kode';
+          if (h.includes('angkatan') || h.includes('tahun')) return 'angkatan';
+          return h.replace(/[^a-z0-9]/g, '_');
+        },
         complete: (results) => {
           const { data, errors } = results;
 


### PR DESCRIPTION
Normalize and alias CSV headers (map nama→nama_lengkap, nim, kode, angkatan/tahun→angkatan) and sanitize other headers. Refactor batchGenerateCodes to a two-phase algorithm that first claims valid provided codes (preventing auto-generation from stealing them) and then auto-generates codes for remaining rows, preserving input order and returning a result per row; failed generations yield an empty code with rule 'FAILED'.