### PR TITLE
feat(import): add Excel import wizard and enhanced asprak validation

### DIFF
--- a/src/app/(dashboard)/asprak/page.tsx
+++ b/src/app/(dashboard)/asprak/page.tsx
@@ -185,7 +185,7 @@ function AsprakPageContent() {
     setShowEditModal(true);
   };
 
-  const handleSaveEdit = async (praktikumIds: string[], newKode: string) => {
+  const handleSaveEdit = async (praktikumIds: string[], newKode: string, forceOverride: boolean) => {
     if (!editTarget) return;
 
     // Use 'all' to indicate global update
@@ -194,7 +194,8 @@ function AsprakPageContent() {
       'all',
       praktikumIds,
       newKode,
-      editTarget.asprak.nim
+      editTarget.asprak.nim,
+      forceOverride
     );
 
     if (result.ok) {

--- a/src/app/api/asprak/route.ts
+++ b/src/app/api/asprak/route.ts
@@ -67,14 +67,15 @@ export async function POST(req: Request) {
         return NextResponse.json({ ok: true, data: result });
       }
       case 'update-assignments': {
-        const { asprakId, term, praktikumIds, newKode, nim } = body;
+        const { asprakId, term, praktikumIds, newKode, nim, forceOverride } = body;
         await asprakService.updateAsprakAssignments(
           asprakId,
           term,
           praktikumIds,
           supabase,
           newKode,
-          nim
+          nim,
+          forceOverride
         );
         return NextResponse.json({ ok: true, data: null });
       }

--- a/src/components/asprak/AsprakCSVPreview.tsx
+++ b/src/components/asprak/AsprakCSVPreview.tsx
@@ -12,6 +12,8 @@ import { CheckCircle, AlertTriangle, Sparkles, ArrowLeft, Save, Copy, FileCheck,
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Checkbox } from '@/components/ui/checkbox';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
 
 export interface PreviewRow {
   nama_lengkap: string;
@@ -38,6 +40,9 @@ interface AsprakCSVPreviewProps {
   onToggleSelect: (rowIndex: number) => void;
   onToggleAll: (checked: boolean) => void;
   loading: boolean;
+  onSkip?: () => void;
+  forceOverride?: boolean;
+  onForceOverrideChange?: (val: boolean) => void;
 }
 
 export default function AsprakCSVPreview({
@@ -49,6 +54,9 @@ export default function AsprakCSVPreview({
   onToggleSelect,
   onToggleAll,
   loading,
+  onSkip,
+  forceOverride = false,
+  onForceOverrideChange
 }: AsprakCSVPreviewProps) {
   const totalOk = rows.filter((r) => r.status === 'ok').length;
   const totalWarning = rows.filter((r) => r.status === 'warning').length;
@@ -128,6 +136,23 @@ export default function AsprakCSVPreview({
           </Badge>
         )}
       </div>
+
+      {onForceOverrideChange !== undefined && (
+        <div className="flex items-center space-x-2 bg-muted/30 p-3 rounded-md border border-border/50">
+          <Switch 
+            id="force-override" 
+            checked={forceOverride}
+            onCheckedChange={onForceOverrideChange}
+            disabled={loading}
+          />
+          <Label htmlFor="force-override" className="text-sm font-medium leading-tight">
+            Paksa gunakan Kode dari CSV
+            <p className="text-xs text-muted-foreground font-normal mt-0.5">
+              Jika diaktifkan, kode yang ada di CSV tidak akan diubah/di-generate ulang, mengabaikan aturan bentrok 5 tahun di database. (Bentrok dalam satu file CSV tetap akan diperingatkan).
+            </p>
+          </Label>
+        </div>
+      )}
 
       {/* Preview Table */}
       <div className="rounded-lg border border-border overflow-hidden">
@@ -296,6 +321,11 @@ export default function AsprakCSVPreview({
             <p className="text-xs text-amber-500">
               {totalError + totalDuplicateCSV} row(s) bermasalah akan di-skip saat import.
             </p>
+          )}
+          {onSkip && (
+              <Button type="button" variant="secondary" onClick={onSkip} disabled={loading}>
+                 Lewati Langkah Ini
+              </Button>
           )}
           <Button
             onClick={onConfirm}

--- a/src/components/jadwal/JadwalCSVPreview.tsx
+++ b/src/components/jadwal/JadwalCSVPreview.tsx
@@ -1,0 +1,235 @@
+import { AlertTriangle, ArrowLeft, CheckCircle, Loader2, Save } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Checkbox } from '@/components/ui/checkbox';
+import { cn } from '@/lib/utils';
+import type { CreateJadwalInput } from '@/services/jadwalService';
+
+export interface JadwalPreviewRow extends CreateJadwalInput {
+  status: 'ok' | 'error' | 'warning';
+  statusMessage: string;
+  mkName: string; // Original MK name from CSV or derived for display
+  fromSystemLogic: boolean; // Tells UI if mkName was auto-matched
+  selected: boolean;
+  originalRow?: number;
+}
+
+interface JadwalCSVPreviewProps {
+  rows: JadwalPreviewRow[];
+  onConfirm: () => void;
+  onBack: () => void;
+  onToggleSelect: (index: number) => void;
+  onToggleAll: (checked: boolean) => void;
+  loading: boolean;
+  onSkip?: () => void;
+}
+
+export default function JadwalCSVPreview({
+  rows,
+  onConfirm,
+  onBack,
+  onToggleSelect,
+  onToggleAll,
+  loading,
+  onSkip,
+}: JadwalCSVPreviewProps) {
+  // ─── Stats for Preview ───────────────────────────────────────────────────
+  const totalOk = rows.filter((r) => r.status === 'ok').length;
+  const totalWarning = rows.filter((r) => r.status === 'warning').length;
+  const totalError = rows.filter((r) => r.status === 'error').length;
+
+  const selectableRows = rows.filter((r) => r.status === 'ok' || r.status === 'warning');
+  const selectedCount = selectableRows.filter((r) => r.selected).length;
+  const allSelected = selectableRows.length > 0 && selectedCount === selectableRows.length;
+  const isIndeterminate = selectedCount > 0 && selectedCount < selectableRows.length;
+
+  return (
+    <div className="space-y-4">
+      {/* Summary Badges using Asprak Preview style */}
+      <div className="flex flex-wrap gap-3 items-center">
+        <Badge variant="outline" className="text-sm px-3 py-1">
+          Total: <span className="font-bold ml-1">{rows.length}</span>
+        </Badge>
+        <Badge
+          variant={selectedCount > 0 ? 'default' : 'outline'}
+          className="text-sm px-3 py-1 transition-colors"
+        >
+          Dipilih: <span className="font-bold ml-1">{selectedCount}</span>
+        </Badge>
+        {totalOk > 0 && (
+          <Badge className="bg-emerald-500/10 text-emerald-500 border-emerald-500/30 text-sm px-3 py-1">
+            <CheckCircle size={14} className="mr-1" />
+            {totalOk} OK
+          </Badge>
+        )}
+        {totalError > 0 && (
+          <Badge className="bg-red-500/10 text-red-500 border-red-500/30 text-sm px-3 py-1">
+            <AlertTriangle size={14} className="mr-1" />
+            {totalError} Error
+          </Badge>
+        )}
+        {totalWarning > 0 && (
+          <Badge className="bg-amber-500/10 text-amber-500 border-amber-500/30 text-sm px-3 py-1">
+            <AlertTriangle size={14} className="mr-1" />
+            {totalWarning} Warning
+          </Badge>
+        )}
+      </div>
+
+      {/* Table Component */}
+      <div className="rounded-lg border border-border overflow-hidden">
+        <div className="overflow-x-auto max-h-[400px] overflow-y-auto">
+          <table className="w-full text-sm border-collapse">
+            <thead className="bg-muted/50 sticky top-0 z-10">
+              <tr>
+                <th className="px-3 py-2.5 text-center border-b border-border w-[40px]">
+                  <Checkbox
+                    checked={
+                      allSelected ? true : isIndeterminate ? 'indeterminate' : false
+                    }
+                    onCheckedChange={(checked) => onToggleAll(!!checked)}
+                    disabled={selectableRows.length === 0}
+                  />
+                </th>
+                <th className="px-3 py-2.5 text-center text-xs font-semibold text-muted-foreground uppercase tracking-wider border-b border-border w-[50px]">
+                  No
+                </th>
+                <th className="px-3 py-2.5 text-left text-xs font-semibold text-muted-foreground uppercase tracking-wider border-b border-border">
+                  Mata Kuliah
+                </th>
+                <th className="px-3 py-2.5 text-left text-xs font-semibold text-muted-foreground uppercase tracking-wider border-b border-border">
+                  Kelas
+                </th>
+                <th className="px-3 py-2.5 text-left text-xs font-semibold text-muted-foreground uppercase tracking-wider border-b border-border">
+                  Data Waktu
+                </th>
+                <th className="px-3 py-2.5 text-left text-xs font-semibold text-muted-foreground uppercase tracking-wider border-b border-border">
+                  Ruangan
+                </th>
+                <th className="px-3 py-2.5 text-left text-xs font-semibold text-muted-foreground uppercase tracking-wider border-b border-border">
+                  Dosen
+                </th>
+                <th className="px-3 py-2.5 text-left text-xs font-semibold text-muted-foreground uppercase tracking-wider border-b border-border">
+                  Status
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row, idx) => {
+                const isDisabled = row.status === 'error';
+                return (
+                  <tr
+                    key={idx}
+                    className={cn(
+                      'border-b border-border/50 transition-colors hover:bg-muted/60',
+                      row.status === 'error' ? 'bg-red-500/5' : '',
+                      row.status === 'warning' ? 'bg-amber-500/5' : '',
+                      !isDisabled && row.selected ? 'bg-muted/40' : ''
+                    )}
+                  >
+                    <td className="px-3 py-2 text-center">
+                      <Checkbox
+                        checked={row.selected}
+                        onCheckedChange={() => onToggleSelect(idx)}
+                        disabled={isDisabled}
+                        className={isDisabled ? 'opacity-50 cursor-not-allowed' : ''}
+                      />
+                    </td>
+                    <td className="px-3 py-2 text-center text-xs font-medium text-muted-foreground">
+                      {row.originalRow}
+                    </td>
+                    <td className="px-3 py-2 font-medium">
+                      <div className="flex items-center gap-2">
+                        <span>{row.mkName}</span>
+                        {row.fromSystemLogic && (
+                          <Badge
+                            variant="outline"
+                            className="text-[9px] h-4 px-1 py-0 shadow-none border-primary/20 text-primary"
+                          >
+                            Auto-Match
+                          </Badge>
+                        )}
+                      </div>
+                      <div className="text-[10px] text-muted-foreground/60 font-mono hidden sm:block">
+                        ID: {row.id_mk || '-'}
+                      </div>
+                    </td>
+                    <td className="px-3 py-2">{row.kelas}</td>
+                    <td className="px-3 py-2">
+                      <div>
+                        {row.hari}, {row.jam}
+                      </div>
+                      <div className="text-[10px] text-muted-foreground/60">
+                        Sesi {row.sesi}
+                      </div>
+                    </td>
+                    <td className="px-3 py-2">{row.ruangan}</td>
+                    <td className="px-3 py-2 truncate max-w-[150px]" title={row.dosen}>
+                      {row.dosen}
+                    </td>
+                    <td className="px-3 py-2">
+                      {row.status === 'ok' && (
+                        <span className="inline-flex items-center gap-1 text-emerald-500 text-xs font-medium">
+                          <CheckCircle size={14} /> OK
+                        </span>
+                      )}
+                      {row.status === 'warning' && (
+                        <span
+                          className="inline-flex items-center gap-1 text-amber-500 text-xs font-medium"
+                          title={row.statusMessage}
+                        >
+                          <AlertTriangle size={14} /> {row.statusMessage}
+                        </span>
+                      )}
+                      {row.status === 'error' && (
+                        <span
+                          className="inline-flex items-center gap-1 text-red-500 text-xs font-medium"
+                          title={row.statusMessage}
+                        >
+                          <AlertTriangle size={14} /> {row.statusMessage}
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Action Buttons */}
+      <div className="flex justify-between items-center pt-2">
+        <Button type="button" variant="outline" onClick={onBack} disabled={loading}>
+          <ArrowLeft size={16} className="mr-1" />
+          Kembali
+        </Button>
+
+        <div className="flex items-center gap-3">
+          {totalError > 0 && (
+            <p className="text-xs text-amber-500">
+              {totalError} row(s) bermasalah akan di-skip.
+            </p>
+          )}
+          {onSkip && (
+              <Button type="button" variant="secondary" onClick={onSkip} disabled={loading}>
+                 Lewati Langkah Ini
+              </Button>
+          )}
+          <Button
+            onClick={onConfirm}
+            disabled={loading || selectedCount === 0}
+            variant="default"
+          >
+            {loading ? (
+              <Loader2 className="animate-spin mr-2" size={16} />
+            ) : (
+              <Save size={16} className="mr-1" />
+            )}
+            {loading ? 'Menyimpan...' : `Simpan ${selectedCount} Data Terpilih`}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/jadwal/JadwalImportCSVModal.tsx
+++ b/src/components/jadwal/JadwalImportCSVModal.tsx
@@ -10,11 +10,6 @@ import {
   FileText,
   X,
   Download,
-  AlertTriangle,
-  Loader2,
-  ArrowLeft,
-  Save,
-  CheckCircle,
 } from 'lucide-react';
 
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -27,6 +22,8 @@ import { cn } from '@/lib/utils';
 import { MataKuliah } from '@/types/database';
 import type { CreateJadwalInput } from '@/services/jadwalService';
 import * as jadwalFetcher from '@/lib/fetchers/jadwalFetcher';
+import JadwalCSVPreview, { JadwalPreviewRow } from './JadwalCSVPreview';
+import { validateJadwalConflicts, buildJadwalPreviewRows } from '@/utils/validation/jadwalValidation';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -43,14 +40,7 @@ interface RawCSVRow {
   mata_kuliah?: string;
 }
 
-interface JadwalPreviewRow extends CreateJadwalInput {
-  status: 'ok' | 'error' | 'warning';
-  statusMessage: string;
-  mkName: string; // Original MK name from CSV or derived for display
-  fromSystemLogic: boolean; // Tells UI if mkName was auto-matched
-  selected: boolean;
-  originalRow?: number;
-}
+
 
 interface JadwalImportCSVModalProps {
   mataKuliahList: MataKuliah[];
@@ -80,114 +70,7 @@ export default function JadwalImportCSVModal({
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
-  // ─── Conflict Validation ───────────────────────────────────────────────────
-
-  const validateConflicts = async (rows: JadwalPreviewRow[]): Promise<JadwalPreviewRow[]> => {
-    if (!term) return rows;
-
-    // 1. Fetch existing schedule from DB
-    const dbResult = await jadwalFetcher.fetchScheduleForValidation(term);
-    const dbSchedule = dbResult.ok ? dbResult.data || [] : [];
-
-    // Helper to generate key
-    const getKey = (hari: string, sesi: number | string, ruangan: string, jam: string) =>
-      `${hari}-${sesi}-${jam}-${ruangan}`;
-    const getFullKey = (
-      id_mk: string,
-      kelas: string,
-      hari: string,
-      sesi: number,
-      ruangan: string
-    ) => `${id_mk}-${kelas}-${hari}-${sesi}-${ruangan}`;
-
-    // Build Maps
-    const dbMap = new Map<string, any>();
-    const dbFullMap = new Set<string>();
-
-    dbSchedule.forEach((s: any) => {
-      if (s.ruangan) {
-        dbMap.set(getKey(s.hari, s.sesi, s.ruangan, s.jam || ''), s);
-        // Also track full check for duplicates
-        dbFullMap.add(getFullKey(s.id_mk.toString(), s.kelas, s.hari, s.sesi, s.ruangan));
-      }
-    });
-
-    // Internal Map to track CSV-internal conflicts
-    const internalMap = new Map<string, number[]>(); // Key -> Array of Row Indexes
-
-    // First pass: Populate internal map
-    rows.forEach((row, idx) => {
-      if (row.status === 'error' || !row.ruangan) return;
-      const key = getKey(row.hari, row.sesi, row.ruangan, row.jam);
-      if (!internalMap.has(key)) {
-        internalMap.set(key, []);
-      }
-      internalMap.get(key)?.push(idx);
-    });
-
-    // Second pass: Apply validations
-    // We map to new objects to avoid mutating state directly if we were using it,
-    // but here we are processing before setting state.
-    return rows.map((row) => {
-      const newRow = { ...row };
-
-      if (newRow.status === 'error') return newRow;
-
-      // Check Exact Duplicate first (id_mk + kelas + hari + sesi + ruangan)
-      const fullKey = getFullKey(
-        newRow.id_mk,
-        newRow.kelas,
-        newRow.hari,
-        newRow.sesi,
-        newRow.ruangan || ''
-      );
-      if (dbFullMap.has(fullKey)) {
-        newRow.status = 'error';
-        newRow.statusMessage = 'Duplikat: Jadwal ini sudah ada di database.';
-        newRow.selected = false;
-        return newRow;
-      }
-
-      // Check Internal Conflict
-      if (newRow.ruangan) {
-        const isCurrentPJJ = newRow.kelas.toUpperCase().includes('PJJ');
-        const key = getKey(newRow.hari, newRow.sesi, newRow.ruangan, newRow.jam);
-        const conflictingIndices = internalMap.get(key) || [];
-
-        // Tabrakan Internal CSV: PJJ is ignored from tabrakan with regular classes,
-        // but can clash with another PJJ? Let's simply allow PJJ to overlap freely.
-        // We filter out conflicts where the OTHER class is PJJ.
-        const activeConflicts = conflictingIndices.filter(
-          (idx) => !rows[idx].kelas.toUpperCase().includes('PJJ')
-        );
-
-        // If the current is NOT PJJ and there's another regular class
-        if (!isCurrentPJJ && activeConflicts.length > 1) {
-          newRow.status = 'error';
-          newRow.statusMessage = `Tabrakan Internal CSV (Baris ${activeConflicts.map((i) => rows[i].originalRow).join(', ')})`;
-          newRow.selected = false;
-          return newRow;
-        }
-
-        // Check DB Conflict
-        if (dbMap.has(key)) {
-          const existing = dbMap.get(key);
-          const isExistingPJJ = existing.kelas.toUpperCase().includes('PJJ');
-
-          if (!isCurrentPJJ && !isExistingPJJ) {
-            newRow.status = 'error';
-            newRow.statusMessage = `Tabrakan Database: Ruangan ${newRow.ruangan} dipakai ${existing.mata_kuliah?.nama_lengkap || 'MK lain'} (${existing.kelas})`;
-            newRow.selected = false;
-            return newRow;
-          }
-        }
-      }
-
-      return newRow;
-    });
-  };
-
-  // ─── CSV Parsing ─────────────────────────────────────────────────────────
+  // Replaced with imported validateJadwalConflicts
 
   const processAndValidate = useCallback(
     (file: File) => {
@@ -222,89 +105,10 @@ export default function JadwalImportCSVModal({
             return;
           }
 
-          // Build preview rows
-          const preview: JadwalPreviewRow[] = [];
-
-          data.forEach((row) => {
-            // 1. Resolve MK using logic identical to Excel Import
-            const mkName = (row.nama_singkat || row.mata_kuliah || '').trim();
-            const kelas = (row.kelas || '').trim();
-            const isPJJ = kelas.toUpperCase().includes('PJJ');
-            const prodi = kelas.split('-')[0].toUpperCase();
-
-            // Filter candidates by term if available
-            const candidates = term
-              ? mataKuliahList.filter((mk) => mk.praktikum?.tahun_ajaran === term)
-              : mataKuliahList;
-
-            // Helper to find exact MK matching name and prodi
-            const findMk = (searchProdi: string) => {
-              return candidates.find(
-                (mk) =>
-                  (mk.praktikum?.nama?.toLowerCase() === mkName.toLowerCase() ||
-                    mk.nama_lengkap.toLowerCase() === mkName.toLowerCase()) &&
-                  mk.program_studi?.toUpperCase() === searchProdi.toUpperCase()
-              );
-            };
-
-            let targetMK = findMk(prodi);
-            if (!targetMK && isPJJ) targetMK = findMk('IF-PJJ');
-            if (!targetMK) targetMK = findMk('IF') || findMk('SE') || findMk('IT') || findMk('DS');
-
-            const mkId = targetMK?.id.toString() || '';
-
-            // 2. Validate Day
-            const hari = (row.hari || '').trim().toUpperCase();
-            const isValidDay = VALID_DAYS.includes(hari);
-
-            // 3. Parse Numbers
-            const sesi = Number(row.sesi || 0);
-            const totalAsprak = Number(row.total_asprak || 0);
-
-            const displayMkName = targetMK ? targetMK.nama_lengkap : mkName;
-
-            let status: 'ok' | 'error' | 'warning' = 'ok';
-            let statusMessage = '';
-
-            if (!targetMK) {
-              status = 'error';
-              statusMessage = `Mata Kuliah "${mkName}" tidak ditemukan.`;
-            } else if (!isValidDay) {
-              status = 'error';
-              statusMessage = `Hari "${hari}" tidak valid.`;
-            } else if (!isPJJ && sesi <= 0) {
-              // Bypass zero session check if it's PJJ (PJJ class validation relaxation)
-              status = 'error';
-              statusMessage = 'Sesi harus > 0 (Kecuali PJJ)';
-            }
-
-            // 4. Cleanup Ruangan
-            let ruanganClean = (row.ruangan || '').trim();
-            if (ruanganClean.includes('&')) {
-              ruanganClean = ruanganClean.split('&')[0].trim();
-            }
-
-            preview.push({
-              id_mk: mkId,
-              kelas: kelas,
-              hari: hari,
-              sesi: sesi,
-              jam: (row.jam || '').trim(),
-              ruangan: ruanganClean,
-              total_asprak: totalAsprak,
-              dosen: (row.dosen || '').trim(),
-              // UI props
-              mkName: displayMkName,
-              fromSystemLogic: !!targetMK,
-              status,
-              statusMessage,
-              selected: status === 'ok',
-              originalRow: preview.length + 2, // 1-indexed plus header
-            });
-          });
+          const preview = buildJadwalPreviewRows(data, mataKuliahList, term);
 
           // APPLY VALIDATION
-          const validatedRows = await validateConflicts(preview);
+          const validatedRows = await validateJadwalConflicts(preview, term || '');
 
           setPreviewRows(validatedRows);
           setStep('preview');
@@ -416,15 +220,7 @@ export default function JadwalImportCSVModal({
     setError(null);
   };
 
-  // ─── Stats for Preview ───────────────────────────────────────────────────
-  const totalOk = previewRows.filter((r) => r.status === 'ok').length;
-  const totalWarning = previewRows.filter((r) => r.status === 'warning').length;
-  const totalError = previewRows.filter((r) => r.status === 'error').length;
 
-  const selectableRows = previewRows.filter((r) => r.status === 'ok' || r.status === 'warning');
-  const selectedCount = selectableRows.filter((r) => r.selected).length;
-  const allSelected = selectableRows.length > 0 && selectedCount === selectableRows.length;
-  const isIndeterminate = selectedCount > 0 && selectedCount < selectableRows.length;
 
   // ─── Render ──────────────────────────────────────────────────────────────
 
@@ -557,188 +353,14 @@ export default function JadwalImportCSVModal({
                   </div>
                 </div>
               ) : (
-                <div className="space-y-4">
-                  {/* Summary Badges using Asprak Preview style */}
-                  <div className="flex flex-wrap gap-3 items-center">
-                    <Badge variant="outline" className="text-sm px-3 py-1">
-                      Total: <span className="font-bold ml-1">{previewRows.length}</span>
-                    </Badge>
-                    <Badge
-                      variant={selectedCount > 0 ? 'default' : 'outline'}
-                      className="text-sm px-3 py-1 transition-colors"
-                    >
-                      Dipilih: <span className="font-bold ml-1">{selectedCount}</span>
-                    </Badge>
-                    {totalOk > 0 && (
-                      <Badge className="bg-emerald-500/10 text-emerald-500 border-emerald-500/30 text-sm px-3 py-1">
-                        <CheckCircle size={14} className="mr-1" />
-                        {totalOk} OK
-                      </Badge>
-                    )}
-                    {totalError > 0 && (
-                      <Badge className="bg-red-500/10 text-red-500 border-red-500/30 text-sm px-3 py-1">
-                        <AlertTriangle size={14} className="mr-1" />
-                        {totalError} Error
-                      </Badge>
-                    )}
-                    {totalWarning > 0 && (
-                      <Badge className="bg-amber-500/10 text-amber-500 border-amber-500/30 text-sm px-3 py-1">
-                        <AlertTriangle size={14} className="mr-1" />
-                        {totalWarning} Warning
-                      </Badge>
-                    )}
-                  </div>
-
-                  {/* Table Component */}
-                  <div className="rounded-lg border border-border overflow-hidden">
-                    <div className="overflow-x-auto max-h-[400px] overflow-y-auto">
-                      <table className="w-full text-sm border-collapse">
-                        <thead className="bg-muted/50 sticky top-0 z-10">
-                          <tr>
-                            <th className="px-3 py-2.5 text-center border-b border-border w-[40px]">
-                              <Checkbox
-                                checked={
-                                  allSelected ? true : isIndeterminate ? 'indeterminate' : false
-                                }
-                                onCheckedChange={(checked) => handleToggleAll(!!checked)}
-                                disabled={selectableRows.length === 0}
-                              />
-                            </th>
-                            <th className="px-3 py-2.5 text-center text-xs font-semibold text-muted-foreground uppercase tracking-wider border-b border-border w-[50px]">
-                              No
-                            </th>
-                            <th className="px-3 py-2.5 text-left text-xs font-semibold text-muted-foreground uppercase tracking-wider border-b border-border">
-                              Mata Kuliah
-                            </th>
-                            <th className="px-3 py-2.5 text-left text-xs font-semibold text-muted-foreground uppercase tracking-wider border-b border-border">
-                              Kelas
-                            </th>
-                            <th className="px-3 py-2.5 text-left text-xs font-semibold text-muted-foreground uppercase tracking-wider border-b border-border">
-                              Data Waktu
-                            </th>
-                            <th className="px-3 py-2.5 text-left text-xs font-semibold text-muted-foreground uppercase tracking-wider border-b border-border">
-                              Ruangan
-                            </th>
-                            <th className="px-3 py-2.5 text-left text-xs font-semibold text-muted-foreground uppercase tracking-wider border-b border-border">
-                              Dosen
-                            </th>
-                            <th className="px-3 py-2.5 text-left text-xs font-semibold text-muted-foreground uppercase tracking-wider border-b border-border">
-                              Status
-                            </th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          {previewRows.map((row, idx) => {
-                            const isDisabled = row.status === 'error';
-                            return (
-                              <tr
-                                key={idx}
-                                className={cn(
-                                  'border-b border-border/50 transition-colors hover:bg-muted/60',
-                                  row.status === 'error' ? 'bg-red-500/5' : '',
-                                  row.status === 'warning' ? 'bg-amber-500/5' : '',
-                                  !isDisabled && row.selected ? 'bg-muted/40' : ''
-                                )}
-                              >
-                                <td className="px-3 py-2 text-center">
-                                  <Checkbox
-                                    checked={row.selected}
-                                    onCheckedChange={() => handleToggleSelect(idx)}
-                                    disabled={isDisabled}
-                                    className={isDisabled ? 'opacity-50 cursor-not-allowed' : ''}
-                                  />
-                                </td>
-                                <td className="px-3 py-2 text-center text-xs font-medium text-muted-foreground">
-                                  {row.originalRow}
-                                </td>
-                                <td className="px-3 py-2 font-medium">
-                                  <div className="flex items-center gap-2">
-                                    <span>{row.mkName}</span>
-                                    {row.fromSystemLogic && (
-                                      <Badge
-                                        variant="outline"
-                                        className="text-[9px] h-4 px-1 py-0 shadow-none border-primary/20 text-primary"
-                                      >
-                                        Auto-Match
-                                      </Badge>
-                                    )}
-                                  </div>
-                                  <div className="text-[10px] text-muted-foreground/60 font-mono hidden sm:block">
-                                    ID: {row.id_mk || '-'}
-                                  </div>
-                                </td>
-                                <td className="px-3 py-2">{row.kelas}</td>
-                                <td className="px-3 py-2">
-                                  <div>
-                                    {row.hari}, {row.jam}
-                                  </div>
-                                  <div className="text-[10px] text-muted-foreground/60">
-                                    Sesi {row.sesi}
-                                  </div>
-                                </td>
-                                <td className="px-3 py-2">{row.ruangan}</td>
-                                <td className="px-3 py-2 truncate max-w-[150px]" title={row.dosen}>
-                                  {row.dosen}
-                                </td>
-                                <td className="px-3 py-2">
-                                  {row.status === 'ok' && (
-                                    <span className="inline-flex items-center gap-1 text-emerald-500 text-xs font-medium">
-                                      <CheckCircle size={14} /> OK
-                                    </span>
-                                  )}
-                                  {row.status === 'warning' && (
-                                    <span
-                                      className="inline-flex items-center gap-1 text-amber-500 text-xs font-medium"
-                                      title={row.statusMessage}
-                                    >
-                                      <AlertTriangle size={14} /> {row.statusMessage}
-                                    </span>
-                                  )}
-                                  {row.status === 'error' && (
-                                    <span
-                                      className="inline-flex items-center gap-1 text-red-500 text-xs font-medium"
-                                      title={row.statusMessage}
-                                    >
-                                      <AlertTriangle size={14} /> {row.statusMessage}
-                                    </span>
-                                  )}
-                                </td>
-                              </tr>
-                            );
-                          })}
-                        </tbody>
-                      </table>
-                    </div>
-                  </div>
-
-                  {/* Action Buttons */}
-                  <div className="flex justify-between items-center pt-2">
-                    <Button type="button" variant="outline" onClick={handleReset} disabled={saving}>
-                      <ArrowLeft size={16} className="mr-1" />
-                      Kembali
-                    </Button>
-
-                    <div className="flex items-center gap-3">
-                      {totalError > 0 && (
-                        <p className="text-xs text-amber-500">
-                          {totalError} row(s) bermasalah akan di-skip.
-                        </p>
-                      )}
-                      <Button
-                        onClick={handleConfirm}
-                        disabled={saving || selectedCount === 0}
-                        variant="default"
-                      >
-                        {saving ? (
-                          <Loader2 className="animate-spin mr-2" size={16} />
-                        ) : (
-                          <Save size={16} className="mr-1" />
-                        )}
-                        {saving ? 'Menyimpan...' : `Simpan ${selectedCount} Data Terpilih`}
-                      </Button>
-                    </div>
-                  </div>
-                </div>
+                <JadwalCSVPreview
+                  rows={previewRows}
+                  onConfirm={handleConfirm}
+                  onBack={handleReset}
+                  onToggleSelect={handleToggleSelect}
+                  onToggleAll={handleToggleAll}
+                  loading={saving}
+                />
               )}
             </div>
           </ScrollArea>

--- a/src/components/mata-kuliah/MataKuliahCSVPreview.tsx
+++ b/src/components/mata-kuliah/MataKuliahCSVPreview.tsx
@@ -37,6 +37,7 @@ interface MataKuliahCSVPreviewProps {
   onUpdateRow: (index: number, updates: Partial<MataKuliahCSVRow>) => void;
   onToggleSelect: (index: number) => void;
   onToggleAll: (checked: boolean) => void;
+  onSkip?: () => void;
 }
 
 export default function MataKuliahCSVPreview({
@@ -48,7 +49,8 @@ export default function MataKuliahCSVPreview({
   onBack,
   onUpdateRow,
   onToggleSelect,
-  onToggleAll
+  onToggleAll,
+  onSkip
 }: MataKuliahCSVPreviewProps) {
   const totalOk = rows.filter((r) => r.status === 'ok').length;
   const totalError = rows.filter((r) => r.status === 'error').length;
@@ -343,6 +345,11 @@ export default function MataKuliahCSVPreview({
             <span className="text-xs text-destructive font-medium mr-3 text-right hidden lg:inline-block">
               {totalError} data bermasalah & akan dilewati
             </span>
+          )}
+          {onSkip && (
+              <Button type="button" variant="secondary" onClick={onSkip} disabled={loading} className="shrink-0 min-w-[140px]">
+                 Lewati Langkah Ini
+              </Button>
           )}
           <Button onClick={onConfirm} disabled={loading || selectedCount === 0} className="shrink-0 min-w-[160px] bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm">
             <Save className="mr-2 h-4 w-4" />

--- a/src/components/pengaturan/excel-steps/StepAsprak.tsx
+++ b/src/components/pengaturan/excel-steps/StepAsprak.tsx
@@ -1,0 +1,228 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { X, Loader2 } from 'lucide-react';
+import AsprakCSVPreview, { PreviewRow } from '../../asprak/AsprakCSVPreview';
+import type { ExistingAsprakInfo } from '../../asprak/AsprakImportCSVModal';
+import { validateAsprakData, validateAsprakCodeEdit } from '@/utils/validation/asprakValidation';
+
+interface StepAsprakProps {
+  data: any[];
+  term: string;
+  onNext: () => void;
+  onPrev?: () => void;
+  onImport: (
+    rows: { nim: string; nama_lengkap: string; kode: string; angkatan: number }[],
+    term: string
+  ) => Promise<void>;
+}
+
+export default function StepAsprak({
+  data,
+  term,
+  onNext,
+  onPrev,
+  onImport,
+}: StepAsprakProps) {
+  const [previewRows, setPreviewRows] = useState<PreviewRow[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [isFetching, setIsFetching] = useState(true);
+  const [forceOverride, setForceOverride] = useState(false);
+  const [showOverrideConfirm, setShowOverrideConfirm] = useState(false);
+
+  // Asprak specific existing data fetched independently
+  const [existingCodes, setExistingCodes] = useState<string[]>([]);
+  const [existingNims, setExistingNims] = useState<string[]>([]);
+  const [existingAspraks, setExistingAspraks] = useState<ExistingAsprakInfo[]>([]);
+
+  useEffect(() => {
+    let active = true;
+
+    async function fetchAsprakInfo() {
+      try {
+        const res = await fetch('/api/asprak?action=all-info');
+        if (!active) return;
+        if (res.ok) {
+          const json = await res.json();
+          if (json.ok && Array.isArray(json.data)) {
+            const dataArr = json.data;
+            setExistingAspraks(dataArr);
+            setExistingCodes(dataArr.map((a: any) => a.kode));
+            setExistingNims(dataArr.map((a: any) => a.nim));
+          }
+        }
+      } catch (err: any) {
+        if (active) {
+            console.error('Failed fetching aspraks info:', err);
+            setError('Gagal mengambil data asprak eksisting.');
+        }
+      } finally {
+        if (active) setIsFetching(false);
+      }
+    }
+
+    fetchAsprakInfo();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  useEffect(() => {
+      if (!data || data.length === 0) {
+          setError('Data Excel Asprak kosong.');
+          return;
+      }
+      
+      try {
+        const preview = validateAsprakData(data, existingCodes, existingNims, forceOverride);
+        setPreviewRows(preview);
+      } catch (e: any) {
+        setError(`Error saat menyiapkan data: ${e.message}`);
+      }
+  }, [data, existingCodes, existingNims, existingAspraks, forceOverride]);
+
+  const handleToggleSelect = useCallback((rowIndex: number) => {
+    setPreviewRows((prev) => {
+      const updated = [...prev];
+      const row = { ...updated[rowIndex] };
+      if (row.status !== 'error' && row.status !== 'duplicate-csv') {
+        row.selected = !row.selected;
+        updated[rowIndex] = row;
+      }
+      return updated;
+    });
+  }, []);
+
+  const handleToggleAll = useCallback((checked: boolean) => {
+    setPreviewRows((prev) => {
+      return prev.map((row) => {
+        if (row.status !== 'error' && row.status !== 'duplicate-csv') {
+          return { ...row, selected: checked };
+        }
+        return row;
+      });
+    });
+  }, []);
+
+  const handleCodeEdit = useCallback(
+    (rowIndex: number, newCode: string) => {
+      setPreviewRows((prev) => validateAsprakCodeEdit(rowIndex, newCode, prev, existingAspraks, forceOverride));
+    },
+    [existingAspraks, forceOverride]
+  );
+
+  const handleForceOverrideToggle = useCallback((checked: boolean) => {
+      if (checked) {
+          setShowOverrideConfirm(true);
+      } else {
+          setForceOverride(false);
+      }
+  }, []);
+
+  const confirmOverride = () => {
+      setForceOverride(true);
+      setShowOverrideConfirm(false);
+  };
+
+  const cancelOverride = () => {
+      setForceOverride(false);
+      setShowOverrideConfirm(false);
+  };
+
+  const handleConfirmImport = async () => {
+    const selectedRows = previewRows.filter(
+      (r) => r.selected && (r.status === 'ok' || r.status === 'warning')
+    );
+
+    if (selectedRows.length === 0) {
+        onNext();
+        return;
+    }
+
+    setSaving(true);
+    setError(null);
+
+    try {
+      await onImport(
+        selectedRows.map((r) => ({
+          nim: r.nim,
+          nama_lengkap: r.nama_lengkap,
+          kode: r.kode,
+          angkatan: r.angkatan,
+        })),
+        term
+      );
+      onNext();
+    } catch (e: any) {
+      setError(e.message || 'Gagal menyimpan data.');
+      setSaving(false);
+    }
+  };
+
+  if (isFetching) {
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center min-h-[400px] bg-background/50 border rounded-md">
+        <Loader2 className="h-8 w-8 animate-spin text-primary mb-4" />
+        <p className="text-sm text-muted-foreground">Memuat data eksisting untuk validasi...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 overflow-hidden flex flex-col min-h-0 bg-background/50 h-[80vh] border rounded-md">
+      {error && (
+        <div className="p-4 shrink-0">
+          <Alert className="border-destructive/50 text-destructive">
+            <AlertDescription className="flex items-start gap-2">
+              <X size={16} className="mt-0.5 flex-shrink-0" />
+              <span className="text-sm">{error}</span>
+            </AlertDescription>
+          </Alert>
+        </div>
+      )}
+
+      <AsprakCSVPreview
+        rows={previewRows}
+        term={term}
+        onConfirm={handleConfirmImport}
+        onBack={onPrev || onNext}
+        onCodeEdit={handleCodeEdit}
+        onToggleSelect={handleToggleSelect}
+        onToggleAll={handleToggleAll}
+        loading={saving}
+        onSkip={onNext}
+        forceOverride={forceOverride}
+        onForceOverrideChange={handleForceOverrideToggle}
+      />
+
+      <AlertDialog open={showOverrideConfirm} onOpenChange={setShowOverrideConfirm}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Konfirmasi Pemaksaan Kode</AlertDialogTitle>
+            <AlertDialogDescription>
+              Apakah Anda yakin ingin memaksakan kode dari CSV?
+              <br /><br />
+              <span className="font-semibold text-destructive">Perhatian:</span> Ini akan mengabaikan peringatan bentrok kode dari database, termasuk kode yang baru saja dipakai dalam selisih kurang dari 5 tahun. Tindakan ini akan me-refresh ulang preview data serta mereset input kode manual yang telah Anda ubah.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={cancelOverride}>Batal</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmOverride} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">Ya, Paksa Gunakan</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/components/pengaturan/excel-steps/StepJadwal.tsx
+++ b/src/components/pengaturan/excel-steps/StepJadwal.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { X, Loader2 } from 'lucide-react';
+import * as jadwalFetcher from '@/lib/fetchers/jadwalFetcher';
+import JadwalCSVPreview, { JadwalPreviewRow } from '../../jadwal/JadwalCSVPreview';
+import { validateJadwalConflicts, buildJadwalPreviewRows } from '@/utils/validation/jadwalValidation';
+
+interface StepJadwalProps {
+  data: any[];
+  term: string;
+  onNext: () => void;
+  onPrev?: () => void;
+  onImport: (rows: any[]) => Promise<void>;
+}
+
+export default function StepJadwal({
+  data,
+  term,
+  onNext,
+  onPrev,
+  onImport,
+}: StepJadwalProps) {
+  const [previewRows, setPreviewRows] = useState<JadwalPreviewRow[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [isFetching, setIsFetching] = useState(true);
+  const [mataKuliahList, setMataKuliahList] = useState<any[]>([]);
+
+  useEffect(() => {
+    let active = true;
+
+    async function fetchMK() {
+        if (!term) return;
+        try {
+            const res = await fetch(`/api/mata-kuliah?term=${term}`);
+            if (!active) return;
+            if (res.ok) {
+                const json = await res.json();
+                if (json.ok && Array.isArray(json.data)) {
+                    // flatten grouped mk to simple list for easier search
+                    const flat = json.data.reduce((acc: any[], group: any) => {
+                        return [...acc, ...group.items];
+                    }, []);
+                    setMataKuliahList(flat);
+                }
+            }
+        } catch (e) {
+            console.error("Failed fetching MK for jadwal", e);
+        } finally {
+            if (active) setIsFetching(false);
+        }
+    }
+    fetchMK();
+    return () => { active = false; };
+  }, [term]);
+
+  // Replaced with imported validateJadwalConflicts
+
+  useEffect(() => {
+    let active = true;
+
+    async function processCSV() {
+        if (!data || data.length === 0) {
+            setError('Data Excel Jadwal kosong.');
+            return;
+        }
+
+        if (mataKuliahList.length === 0) {
+            // Wait for mata kuliah list to load if needed. 
+            // Technically it could be empty if term has no MK yet, 
+            // but usually we import MK before Jadwal in this flow anyway.
+        }
+
+        const preview = buildJadwalPreviewRows(data, mataKuliahList, term);
+
+        const validatedRows = await validateJadwalConflicts(preview, term);
+        if (active) setPreviewRows(validatedRows);
+    }
+    
+    processCSV();
+
+    return () => { active = false; };
+  }, [data, mataKuliahList, term]);
+
+  const handleToggleSelect = (index: number) => {
+    setPreviewRows((prev) => {
+      const next = [...prev];
+      if (next[index].status !== 'error') {
+        next[index].selected = !next[index].selected;
+      }
+      return next;
+    });
+  };
+
+  const handleToggleAll = (checked: boolean) => {
+    setPreviewRows((prev) =>
+      prev.map((r) => (r.status !== 'error' ? { ...r, selected: checked } : r))
+    );
+  };
+
+  const handleConfirm = async () => {
+    const selected = previewRows.filter((r) => r.selected && r.status !== 'error');
+    if (selected.length === 0) {
+        onNext();
+        return;
+    }
+
+    setSaving(true);
+    try {
+      const payload = selected.map((r) => ({
+        id_mk: r.id_mk,
+        kelas: r.kelas,
+        hari: r.hari,
+        sesi: r.sesi,
+        jam: r.jam,
+        ruangan: r.ruangan,
+        total_asprak: r.total_asprak,
+        dosen: r.dosen,
+      }));
+
+      await onImport(payload);
+      onNext();
+    } catch (err: any) {
+      setError(err.message || 'Gagal menyimpan data Jadwal');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (isFetching) {
+    return (
+       <div className="flex-1 flex flex-col items-center justify-center min-h-[400px] bg-background/50 border rounded-md">
+         <Loader2 className="h-8 w-8 animate-spin text-primary mb-4" />
+         <p className="text-sm text-muted-foreground">Memuat data eksisting untuk validasi...</p>
+       </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 overflow-hidden flex flex-col min-h-0 bg-background/50 h-[80vh] border rounded-md">
+       {error && (
+        <div className="p-4 shrink-0 pb-0">
+          <Alert className="border-destructive/50 text-destructive">
+            <AlertDescription className="flex items-start gap-2">
+              <X size={16} className="mt-0.5 flex-shrink-0" />
+              <span className="text-sm">{error}</span>
+            </AlertDescription>
+          </Alert>
+        </div>
+      )}
+
+      <div className="p-4 flex-1 h-full max-h-full">
+          <JadwalCSVPreview
+            rows={previewRows}
+            onConfirm={handleConfirm}
+            onBack={onPrev || onNext}
+            onToggleSelect={handleToggleSelect}
+            onToggleAll={handleToggleAll}
+            loading={saving}
+            onSkip={onNext}
+          />
+      </div>
+    </div>
+  );
+}

--- a/src/components/pengaturan/excel-steps/StepMataKuliah.tsx
+++ b/src/components/pengaturan/excel-steps/StepMataKuliah.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import { toast } from 'sonner';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { X, Loader2 } from 'lucide-react';
+import MataKuliahCSVPreview, { MataKuliahCSVRow } from '../../mata-kuliah/MataKuliahCSVPreview';
+import { validateMataKuliahData } from '@/utils/validation/mataKuliahValidation';
+import type { MataKuliahGrouped } from '@/services/mataKuliahService';
+
+interface StepMataKuliahProps {
+  data: any[];
+  term: string;
+  onNext: () => void;
+  onPrev?: () => void;
+  onImport: (rows: any[], term: string) => Promise<void>;
+}
+
+export default function StepMataKuliah({
+  data,
+  term,
+  onNext,
+  onPrev,
+  onImport,
+}: StepMataKuliahProps) {
+  const [parsedRows, setParsedRows] = useState<MataKuliahCSVRow[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [isFetching, setIsFetching] = useState(true);
+  const [localValidPraktikums, setLocalValidPraktikums] = useState<{ id: string; nama: string }[]>([]);
+  const [existingMataKuliah, setExistingMataKuliah] = useState<MataKuliahGrouped[]>([]);
+  
+  const isValidProdi = (prodi: string) => {
+    const base = prodi?.replace('-PJJ', '') || '';
+    return ['IF', 'IT', 'SE', 'DS'].includes(base);
+  };
+
+  // Fetch valid praktikums AND existing MK for the term
+  useEffect(() => {
+    let active = true;
+
+    async function fetchData() {
+      if (!term || term.length < 6) return; // e.g., '2425-2'
+
+      try {
+        const [praktikumRes, mkRes] = await Promise.all([
+          fetch(`/api/praktikum?action=by-term&term=${term}`),
+          fetch(`/api/mata-kuliah?term=${term}`),
+        ]);
+
+        if (active && praktikumRes.ok) {
+          const json = await praktikumRes.json();
+          if (json.ok && Array.isArray(json.data)) {
+            setLocalValidPraktikums(json.data);
+          } else {
+            setLocalValidPraktikums([]);
+          }
+        }
+
+        if (active && mkRes.ok) {
+          const mkJson = await mkRes.json();
+          if (mkJson.ok && Array.isArray(mkJson.data)) {
+            setExistingMataKuliah(mkJson.data);
+          } else {
+            setExistingMataKuliah([]);
+          }
+        }
+      } catch (e: any) {
+        console.error(e);
+      } finally {
+        if (active) setIsFetching(false);
+      }
+    }
+
+    fetchData();
+    return () => {
+      active = false;
+    };
+  }, [term]);
+
+  // Process data after fetch is complete (or updated)
+  useEffect(() => {
+      if (!data || data.length === 0) {
+          setError('Data Excel Mata Kuliah kosong.');
+          return;
+      }
+      
+      const transformed = validateMataKuliahData(data, localValidPraktikums, existingMataKuliah);
+      setParsedRows(transformed);
+  }, [data, localValidPraktikums, existingMataKuliah]);
+
+  const handleUpdateRow = (index: number, updates: Partial<MataKuliahCSVRow>) => {
+    const newRows = [...parsedRows];
+    newRows[index] = { ...newRows[index], ...updates };
+    setParsedRows(newRows);
+  };
+
+  const handleToggleSelect = (index: number) => {
+    const newRows = [...parsedRows];
+    newRows[index].selected = !newRows[index].selected;
+    setParsedRows(newRows);
+  };
+
+  const handleToggleAll = (checked: boolean) => {
+    const newRows = parsedRows.map((r) => ({
+      ...r,
+      selected: r.status === 'error' ? false : checked,
+    }));
+    setParsedRows(newRows);
+  };
+
+  const handleConfirmImport = async () => {
+    try {
+      const selectedRows = parsedRows.filter((r) => r.selected);
+      if (selectedRows.length === 0) {
+        onNext();
+        return;
+      }
+
+      setLoading(true);
+      const rowsToImport = selectedRows.map((r) => ({
+        mk_singkat: r.mk_singkat,
+        nama_lengkap: r.nama_lengkap,
+        program_studi: r.program_studi,
+        dosen_koor: r.dosen_koor,
+      }));
+
+      await onImport(rowsToImport, term);
+      onNext();
+    } catch (e: any) {
+      setError(e.message);
+      setLoading(false);
+    } 
+  };
+
+  if (isFetching) {
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center min-h-[400px] bg-background/50 border rounded-md">
+        <Loader2 className="h-8 w-8 animate-spin text-primary mb-4" />
+        <p className="text-sm text-muted-foreground">Memuat data eksisting untuk validasi...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 overflow-hidden flex flex-col min-h-0 bg-background/50 h-[80vh] border rounded-md">
+      {error && (
+        <div className="p-4 shrink-0">
+          <Alert className="border-destructive/50 text-destructive">
+            <AlertDescription className="flex items-start gap-2">
+              <X size={16} className="mt-0.5 flex-shrink-0" />
+              <span className="text-sm">{error}</span>
+            </AlertDescription>
+          </Alert>
+        </div>
+      )}
+
+      <MataKuliahCSVPreview
+        rows={parsedRows}
+        loading={loading}
+        validPraktikums={localValidPraktikums}
+        term={term}
+        onConfirm={handleConfirmImport}
+        onBack={onPrev || onNext} // Skip/Next representation in sequence
+        onUpdateRow={handleUpdateRow}
+        onToggleSelect={handleToggleSelect}
+        onToggleAll={handleToggleAll}
+        onSkip={onNext}
+      />
+    </div>
+  );
+}

--- a/src/components/pengaturan/excel-steps/StepPlotting.tsx
+++ b/src/components/pengaturan/excel-steps/StepPlotting.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { X, Loader2 } from 'lucide-react';
+import { validatePlottingImport, savePlotting } from '@/lib/fetchers/plottingFetcher';
+import PlottingCSVPreview from '../../plotting/PlottingCSVPreview';
+import { mapPlottingValidationResponse, handlePlottingResolve, ExtendedPreviewRow } from '@/utils/validation/plottingValidation';
+
+interface StepPlottingProps {
+  data: any[];
+  term: string;
+  onNext: () => void;
+  onPrev?: () => void;
+  onSuccess: () => void;
+}
+
+export default function StepPlotting({
+  data,
+  term,
+  onNext,
+  onPrev,
+  onSuccess,
+}: StepPlottingProps) {
+  const [previewRows, setPreviewRows] = useState<ExtendedPreviewRow[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [isValidating, setIsValidating] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+
+    async function processData() {
+        if (!data || data.length === 0) {
+            setError('Data Excel Penugasan (Plotting) kosong.');
+            setIsValidating(false);
+            return;
+        }
+
+        if (!term) return;
+
+        setIsValidating(true);
+        setError(null);
+
+        const rawRows = data.map((row: any) => ({
+            kode_asprak: (row.kode_asprak || row['Kode Asprak'] || row.kode || row.Kode || '').trim(),
+            mk_singkat: (row.mk_singkat || row['MK Singkat'] || row.mk || row.MK || '').trim(),
+        })).filter((r: any) => r.kode_asprak && r.mk_singkat);
+
+        if (rawRows.length === 0) {
+            if (active) {
+                setError('Data Excel kosong atau kolom (kode_asprak, mk_singkat) tidak sesuai.');
+                setIsValidating(false);
+            }
+            return;
+        }
+
+        // Validate via API
+        const res = await validatePlottingImport(rawRows, term);
+        
+        if (!active) return;
+        setIsValidating(false);
+
+        if (res.ok && res.data) {
+           const mapped = mapPlottingValidationResponse(res.data);
+           setPreviewRows(mapped);
+        } else {
+           setError(res.error || 'Validation failed');
+        }
+    }
+
+    processData();
+
+    return () => {
+        active = false;
+    };
+  }, [data, term]);
+
+  const handleResolve = (index: number, candidateId: string) => {
+      setPreviewRows((prev) => handlePlottingResolve(index, candidateId, prev));
+  };
+
+  const handleConfirm = async () => {
+      const payload: {asprak_id: string, praktikum_id: string}[] = [];
+      
+      previewRows.forEach(row => {
+          if (!row.selected) return;
+          if (row.status === 'invalid') return;
+          
+          // Valid rows
+          if (row.status === 'valid' && row.asprakId && row.praktikumId) {
+              payload.push({ asprak_id: row.asprakId, praktikum_id: row.praktikumId });
+          }
+          
+          // Ambiguous rows (resolved via multiple selection)
+          else if (row.status === 'ambiguous' && row.selectedCandidateIds && row.praktikumId) {
+              row.selectedCandidateIds.forEach((id: string) => {
+                  payload.push({ asprak_id: id, praktikum_id: row.praktikumId! });
+              });
+          }
+      });
+      
+      if (payload.length === 0) {
+          onNext();
+          return;
+      }
+
+      setLoading(true);
+      const res = await savePlotting(payload);
+      setLoading(false);
+      
+      if (res.ok) {
+          onSuccess();
+          onNext();
+      } else {
+          setError(res.error || 'Gagal menyimpan penugasan asprak');
+      }
+  };
+
+  if (isValidating) {
+    return (
+       <div className="flex-1 flex flex-col items-center justify-center min-h-[400px] bg-background/50 border rounded-md">
+         <Loader2 className="h-8 w-8 animate-spin text-primary mb-4" />
+         <p className="text-sm text-muted-foreground">Memvalidasi data plotting dengan database...</p>
+       </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 overflow-hidden flex flex-col min-h-0 bg-background/50 h-[80vh] border rounded-md">
+       {error && (
+        <div className="p-4 shrink-0 pb-0">
+          <Alert className="border-destructive/50 text-destructive">
+            <AlertDescription className="flex items-start gap-2">
+              <X size={16} className="mt-0.5 flex-shrink-0" />
+              <span className="text-sm">{error}</span>
+            </AlertDescription>
+          </Alert>
+        </div>
+      )}
+
+      <PlottingCSVPreview
+        rows={previewRows}
+        term={term}
+        onConfirm={handleConfirm}
+        onBack={onPrev || onNext}
+        onResolve={handleResolve}
+        onToggleSelect={(idx: number) => setPreviewRows(p => {
+            const u = [...p]; u[idx].selected = !u[idx].selected; return u;
+        })}
+        onToggleAll={(checked: boolean) => setPreviewRows(p => p.map(r => r.status==='invalid' ? r : {...r, selected: checked}))}
+        loading={loading}
+        onSkip={onNext}
+      />
+    </div>
+  );
+}

--- a/src/components/pengaturan/excel-steps/StepPraktikum.tsx
+++ b/src/components/pengaturan/excel-steps/StepPraktikum.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { X, Loader2 } from 'lucide-react';
+import PraktikumCSVPreview, { PraktikumPreviewRow } from '../../praktikum/PraktikumCSVPreview';
+import { validatePraktikumData } from '@/utils/validation/praktikumValidation';
+import { fetchAllPraktikum } from '@/lib/fetchers/praktikumFetcher';
+
+interface StepPraktikumProps {
+  data: any[];
+  onNext: () => void;
+  onPrev?: () => void;
+  onImport: (rows: { nama: string; tahun_ajaran: string }[]) => Promise<void>;
+}
+
+export default function StepPraktikum({
+  data,
+  onNext,
+  onPrev,
+  onImport,
+}: StepPraktikumProps) {
+  const [previewRows, setPreviewRows] = useState<PraktikumPreviewRow[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [isFetching, setIsFetching] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+
+    async function process() {
+        if (!data || data.length === 0) {
+          setError('Data CSV/Excel Praktikum kosong.');
+          return;
+        }
+
+        try {
+            const res = await fetchAllPraktikum();
+            if (!active) return;
+
+            let existing: {nama: string; tahun_ajaran: string}[] = [];
+            if (res.ok && res.data) {
+                existing = res.data.map((p: any) => ({
+                    nama: p.nama,
+                    tahun_ajaran: p.tahun_ajaran
+                }));
+            }
+
+            const preview = validatePraktikumData(data, existing);
+            setPreviewRows(preview);
+        } catch (err: any) {
+             if (active) setError(err.message || 'Gagal memuat data praktikum dari database untuk validasi.');
+        } finally {
+             if (active) setIsFetching(false);
+        }
+    }
+
+    process();
+
+    return () => { active = false; };
+  }, [data]);
+
+  const handleToggleSelect = useCallback((rowIndex: number) => {
+    setPreviewRows((prev) => {
+      const updated = [...prev];
+      const row = { ...updated[rowIndex] };
+      if (row.status !== 'error' && row.status !== 'skipped') {
+        row.selected = !row.selected;
+        updated[rowIndex] = row;
+      }
+      return updated;
+    });
+  }, []);
+
+  const handleToggleAll = useCallback((checked: boolean) => {
+    setPreviewRows((prev) => {
+      return prev.map((row) => {
+        if (row.status !== 'error' && row.status !== 'skipped') {
+          return { ...row, selected: checked };
+        }
+        return row;
+      });
+    });
+  }, []);
+
+  const handleConfirm = async () => {
+    const selectedRows = previewRows.filter((r) => r.selected);
+    if (selectedRows.length === 0) {
+      onNext();
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+
+    try {
+      await onImport(
+        selectedRows.map((r) => ({
+          nama: r.nama,
+          tahun_ajaran: r.tahun_ajaran,
+        }))
+      );
+      onNext();
+    } catch (e: any) {
+      setError(e.message || 'Gagal menyimpan data.');
+      setSaving(false);
+    }
+  };
+
+  if (isFetching) {
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center min-h-[400px] bg-background/50 border rounded-md">
+        <Loader2 className="h-8 w-8 animate-spin text-primary mb-4" />
+        <p className="text-sm text-muted-foreground">Memuat data eksisting untuk validasi...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {error && (
+        <Alert className="mb-4 border-destructive/50 text-destructive">
+          <AlertDescription className="flex items-start gap-2">
+            <X size={16} className="mt-0.5 flex-shrink-0" />
+            <span className="text-sm">{error}</span>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <PraktikumCSVPreview
+        rows={previewRows}
+        onConfirm={handleConfirm}
+        onBack={onPrev || onNext} 
+        onToggleSelect={handleToggleSelect}
+        onToggleAll={handleToggleAll}
+        loading={saving}
+        onSkip={onNext}
+      />
+    </div>
+  );
+}

--- a/src/components/plotting/PlottingCSVPreview.tsx
+++ b/src/components/plotting/PlottingCSVPreview.tsx
@@ -25,6 +25,7 @@ interface PlottingCSVPreviewProps {
   onToggleSelect: (rowIndex: number) => void;
   onToggleAll: (checked: boolean) => void;
   loading: boolean;
+  onSkip?: () => void;
 }
 
 export default function PlottingCSVPreview({
@@ -36,6 +37,7 @@ export default function PlottingCSVPreview({
   onToggleSelect,
   onToggleAll,
   loading,
+  onSkip,
 }: PlottingCSVPreviewProps) {
   const totalValid = rows.filter(r => r.status === 'valid').length;
   // Resolved ambiguous rows count as valid for saving purposes?
@@ -194,10 +196,17 @@ export default function PlottingCSVPreview({
          <Button variant="outline" onClick={onBack} disabled={loading}>
              <ArrowLeft size={16} className="mr-1" /> Back
          </Button>
-         <Button onClick={onConfirm} disabled={loading || validAssignmentsCount === 0} variant="default">
-             <Save size={16} className="mr-1" />
-             {loading ? 'Saving...' : `Save ${validAssignmentsCount} Assignments`}
-         </Button>
+         <div className="flex gap-2">
+           {onSkip && (
+              <Button type="button" variant="secondary" onClick={onSkip} disabled={loading}>
+                 Lewati Langkah Ini
+              </Button>
+           )}
+           <Button onClick={onConfirm} disabled={loading || validAssignmentsCount === 0} variant="default">
+               <Save size={16} className="mr-1" />
+               {loading ? 'Saving...' : `Save ${validAssignmentsCount} Assignments`}
+           </Button>
+         </div>
       </div>
     </div>
   );

--- a/src/components/plotting/PlottingImportModal.tsx
+++ b/src/components/plotting/PlottingImportModal.tsx
@@ -28,7 +28,8 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { cn } from '@/lib/utils';
 
 import { validatePlottingImport, savePlotting } from '@/lib/fetchers/plottingFetcher';
-import PlottingCSVPreview, { PlottingPreviewRow } from './PlottingCSVPreview';
+import PlottingCSVPreview from './PlottingCSVPreview';
+import { mapPlottingValidationResponse, handlePlottingResolve, ExtendedPreviewRow } from '@/utils/validation/plottingValidation';
 
 interface PlottingImportModalProps {
   open: boolean;
@@ -36,12 +37,6 @@ interface PlottingImportModalProps {
   onSuccess: () => void;
   terms: string[];
 }
-
-// Extend row type to hold internal IDs
-type ExtendedPreviewRow = PlottingPreviewRow & { 
-    asprakId?: string; 
-    praktikumId?: string; 
-};
 
 export default function PlottingImportModal({
   open,
@@ -83,50 +78,7 @@ export default function PlottingImportModal({
         setLoading(false);
 
         if (res.ok && res.data) {
-           const { validRows, ambiguousRows, invalidRows } = res.data;
-           
-           const mapped: ExtendedPreviewRow[] = [];
-           let idx = 0;
-
-           // Valid
-           validRows.forEach((r: any) => {
-               mapped.push({
-                   index: idx++,
-                   kode_asprak: r.original?.kode_asprak || '???',
-                   mk_singkat: r.original?.mk_singkat || '???',
-                   status: 'valid',
-                   selected: true,
-                   asprakId: r.asprak_id,
-                   praktikumId: r.praktikum_id
-               });
-           });
-
-           // Ambiguous
-           ambiguousRows.forEach(r => {
-               mapped.push({
-                   index: idx++,
-                   kode_asprak: r.original.kode_asprak,
-                   mk_singkat: r.original.mk_singkat,
-                   status: 'ambiguous',
-                   message: r.reason,
-                   candidates: r.candidates,
-                   selected: true, // Selected by default, but no candidates selected yet
-                   selectedCandidateIds: [], // Empty initially
-                   praktikumId: r.praktikum_id
-               });
-           });
-
-           // Invalid
-           invalidRows.forEach(r => {
-               mapped.push({
-                   index: idx++,
-                   kode_asprak: r.original.kode_asprak,
-                   mk_singkat: r.original.mk_singkat,
-                   status: 'invalid',
-                   message: r.reason,
-                   selected: false
-               });
-           });
+           const mapped = mapPlottingValidationResponse(res.data);
            
            setPreviewRows(mapped);
            setStep('preview');
@@ -173,20 +125,7 @@ export default function PlottingImportModal({
   };
 
   const handleResolve = (index: number, candidateId: string) => {
-      setPreviewRows(prev => {
-          const update = [...prev];
-          const row = { ...update[index] };
-          
-          const currentIds = row.selectedCandidateIds || [];
-          if (currentIds.includes(candidateId)) {
-              row.selectedCandidateIds = currentIds.filter(id => id !== candidateId);
-          } else {
-              row.selectedCandidateIds = [...currentIds, candidateId];
-          }
-          
-          update[index] = row;
-          return update;
-      });
+      setPreviewRows((prev) => handlePlottingResolve(index, candidateId, prev));
   };
 
   const handleConfirm = async () => {

--- a/src/components/praktikum/PraktikumCSVPreview.tsx
+++ b/src/components/praktikum/PraktikumCSVPreview.tsx
@@ -23,6 +23,7 @@ interface PraktikumCSVPreviewProps {
   onToggleSelect: (rowIndex: number) => void;
   onToggleAll: (checked: boolean) => void;
   loading: boolean;
+  onSkip?: () => void; // Added for Excel import wizard
 }
 
 export default function PraktikumCSVPreview({
@@ -32,6 +33,7 @@ export default function PraktikumCSVPreview({
   onToggleSelect,
   onToggleAll,
   loading,
+  onSkip,
 }: PraktikumCSVPreviewProps) {
   const totalOk = rows.filter((r) => r.status === 'ok').length;
   const totalSkipped = rows.filter((r) => r.status === 'skipped').length;
@@ -164,14 +166,21 @@ export default function PraktikumCSVPreview({
           Kembali
         </Button>
 
-        <Button
-            onClick={onConfirm}
-            disabled={loading || selectedCount === 0}
-            variant="default"
-        >
-            <Save size={16} className="mr-1" />
-            {loading ? 'Menyimpan...' : `Simpan ${selectedCount} Data Terpilih`}
-        </Button>
+        <div className="flex items-center gap-2">
+           {onSkip && (
+              <Button type="button" variant="secondary" onClick={onSkip} disabled={loading}>
+                 Lewati Langkah Ini
+              </Button>
+           )}
+           <Button
+               onClick={onConfirm}
+               disabled={loading || selectedCount === 0}
+               variant="default"
+           >
+               <Save size={16} className="mr-1" />
+               {loading ? 'Menyimpan...' : `Simpan ${selectedCount} Data Terpilih`}
+           </Button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/praktikum/PraktikumImportModal.tsx
+++ b/src/components/praktikum/PraktikumImportModal.tsx
@@ -13,8 +13,10 @@ import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { cn } from '@/lib/utils';
 
-// Import the Preview Component we just created
+// Import the Preview Component
 import PraktikumCSVPreview, { PraktikumPreviewRow } from './PraktikumCSVPreview';
+// Import Validation Logic
+import { validatePraktikumData } from '@/utils/validation/praktikumValidation';
 
 // We reuse TermInput to set the term globally? 
 // Or do we read term from CSV?
@@ -73,42 +75,7 @@ export default function PraktikumImportModal({
           // User said: "kolom nama_singkat, tahun_ajaran".
           // I will look for 'nama_singkat' OR 'nama'.
           
-          const preview: PraktikumPreviewRow[] = [];
-          
-          data.forEach((row: any) => {
-            const nama = (row.nama_singkat || row.nama || '').trim().toUpperCase();
-            const tahunAjaran = (row.tahun_ajaran || '').trim();
-            
-            let status: PraktikumPreviewRow['status'] = 'ok';
-            let statusMessage = '';
-            let selected = true;
-
-            if (!nama) {
-                status = 'error';
-                statusMessage = 'Nama kosong';
-                selected = false;
-            } else if (!tahunAjaran) {
-                status = 'error';
-                statusMessage = 'Tahun Ajaran kosong';
-                selected = false;
-            } else {
-                // Check exist
-                const exists = existingPraktikums.some(p => p.nama === nama && p.tahun_ajaran === tahunAjaran);
-                if (exists) {
-                    status = 'skipped';
-                    statusMessage = 'Sudah ada di database';
-                    selected = false;
-                }
-            }
-            
-            preview.push({
-                nama,
-                tahun_ajaran: tahunAjaran,
-                status,
-                statusMessage,
-                selected
-            });
-          });
+          const preview = validatePraktikumData(data, existingPraktikums);
 
           setPreviewRows(preview);
           setStep('preview');

--- a/src/lib/fetchers/asprakFetcher.ts
+++ b/src/lib/fetchers/asprakFetcher.ts
@@ -16,6 +16,7 @@ export interface UpsertAsprakInput {
     term: string;
     praktikumNames: string[];
   }[];
+  forceOverride?: boolean;
 }
 
 export interface AsprakAssignment {
@@ -100,7 +101,8 @@ export async function updateAssignments(
   term: string,
   praktikumIds: string[],
   newKode?: string,
-  nim?: string
+  nim?: string,
+  forceOverride?: boolean
 ): Promise<ServiceResult<void>> {
   try {
     const res = await fetch('/api/asprak', {
@@ -113,6 +115,7 @@ export async function updateAssignments(
         praktikumIds,
         newKode,
         nim,
+        forceOverride,
       }),
     });
 
@@ -252,7 +255,7 @@ export async function checkNim(nim: string): Promise<ServiceResult<boolean>> {
     });
     const json = await res.json();
     if (!res.ok) return { ok: false, error: json.error };
-    return { ok: true, data: json.exists };
+    return { ok: true, data: json.data?.exists || false };
   } catch (e: any) {
     return { ok: false, error: e.message };
   }

--- a/src/utils/asprakCodeGenerator.ts
+++ b/src/utils/asprakCodeGenerator.ts
@@ -247,10 +247,11 @@ export function generateAsprakCode(
   else if (n === 2) standardCandidates = rulesFor2Words(words);
   else standardCandidates = rulesFor3Words(words);
 
+  const rulePrefix = Math.min(n, 3);
   for (let i = 0; i < standardCandidates.length; i++) {
     const code = standardCandidates[i].toUpperCase();
     if (isValidCode(code) && !usedCodes.has(code)) {
-      return { code, rule: `Standard ${n}.${i + 1}` };
+      return { code, rule: `Standard ${rulePrefix}.${i + 1}` };
     }
   }
 

--- a/src/utils/validation/asprakValidation.ts
+++ b/src/utils/validation/asprakValidation.ts
@@ -1,0 +1,221 @@
+import { PreviewRow } from '@/components/asprak/AsprakCSVPreview';
+import { batchGenerateCodes } from '@/utils/asprakCodeGenerator';
+import type { ExistingAsprakInfo } from '@/components/asprak/AsprakImportCSVModal';
+
+const CODE_RECYCLE_YEARS = 5;
+
+export function validateAsprakData(
+  data: any[],
+  existingCodes: string[],
+  existingNims: string[],
+  forceOverride: boolean = false
+): PreviewRow[] {
+  const usedCodes = new Set(existingCodes.map((c) => c.toUpperCase()));
+  const existingNimSet = new Set(existingNims);
+
+  // Map column variations mapped from headers
+  const normalizedData = data.map((r: any) => {
+    // Find keys case-insensitively
+    const keys = Object.keys(r);
+    const getVal = (possibleNames: string[]) => {
+      for (const p of possibleNames) {
+        const found = keys.find(k => k.toLowerCase().replace(/[^a-z0-9]/g, '') === p.toLowerCase().replace(/[^a-z0-9]/g, ''));
+        if (found) return r[found];
+      }
+      return undefined;
+    };
+
+    return {
+      nama_lengkap: String(getVal(['nama_lengkap', 'namalengkap', 'nama']) || '').trim(),
+      nim: String(getVal(['nim']) || '').trim(),
+      kode: getVal(['kode']) ? String(getVal(['kode'])).trim() : undefined,
+      angkatan: getVal(['angkatan', 'tahun']),
+    };
+  });
+
+  // Prepare rows for batch code generation
+  const rowsForCodeGen = normalizedData.map((row) => ({
+    nama_lengkap: row.nama_lengkap,
+    kode: row.kode,
+  }));
+
+  const generatedCodes = batchGenerateCodes(rowsForCodeGen, forceOverride ? new Set() : usedCodes);
+
+  const preview: PreviewRow[] = [];
+  const seenNimsInCSV = new Set<string>();
+
+  for (let idx = 0; idx < normalizedData.length; idx++) {
+    const row = normalizedData[idx];
+    const namaLengkap = row.nama_lengkap;
+    const nim = row.nim;
+    const rawAngkatan = row.angkatan;
+    let angkatan =
+      typeof rawAngkatan === 'number'
+        ? rawAngkatan
+        : parseInt(String(rawAngkatan || '0'), 10);
+    if (angkatan > 0 && angkatan < 100) angkatan += 2000;
+
+    const originalKode = row.kode ? row.kode.toUpperCase() : '';
+    const generated = generatedCodes[idx];
+
+    // Determine status
+    let status: PreviewRow['status'] = 'ok';
+    let statusMessage = '';
+
+    if (!namaLengkap) {
+      status = 'error';
+      statusMessage = 'Nama kosong';
+    } else if (!nim) {
+      status = 'error';
+      statusMessage = 'NIM kosong';
+    } else if (existingNimSet.has(nim)) {
+      status = 'error';
+      statusMessage = 'Duplikat — NIM sudah ada di database';
+    } else if (seenNimsInCSV.has(nim)) {
+      status = 'duplicate-csv';
+      statusMessage = 'Duplikat dalam CSV — NIM sama dengan row sebelumnya';
+    } else if (angkatan <= 0 || isNaN(angkatan)) {
+      status = 'warning';
+      statusMessage = 'Angkatan tidak valid';
+    }
+
+    // Check if code generation failed
+    if (generated.rule === 'FAILED' && !originalKode && status === 'ok') {
+      status = 'error';
+      statusMessage = 'Kode gagal di-generate — isi manual di kolom kode';
+    }
+
+    // Track this NIM as seen in current CSV
+    if (nim) seenNimsInCSV.add(nim);
+
+    const codeSource: PreviewRow['codeSource'] =
+      generated.rule === 'Provided (CSV)' ? 'csv' : 'generated';
+
+    const isDuplicate =
+      (status === 'error' && statusMessage.includes('Duplikat')) ||
+      status === 'duplicate-csv';
+      
+    // If forceOverride is true, and originalKode exists in the CSV, we use it directly
+    // and ignore DB conflicts (the code generator will still have tried to generate a unique one if we didn't pass empty usedCodes)
+    let finalCodeRule = isDuplicate ? 'Duplikat' : generated.rule;
+    let finalDisplayKode = isDuplicate && originalKode ? originalKode : generated.code;
+    let finalCodeSource = codeSource;
+    let finalStatus = status;
+    let finalStatusMessage = statusMessage;
+
+    if (forceOverride && originalKode) {
+      finalDisplayKode = originalKode;
+      if (!isDuplicate) {
+        finalCodeRule = 'Provided (CSV) [Forced]';
+      }
+      finalCodeSource = 'csv';
+      // Only clear code generation failures, preserve NIM duplicate errors
+      if (finalStatusMessage.includes('Kode gagal di-generate')) {
+        finalStatus = 'ok';
+        finalStatusMessage = '';
+      }
+    }
+
+    preview.push({
+      nama_lengkap: namaLengkap.toUpperCase(),
+      nim,
+      kode: finalDisplayKode,
+      angkatan: isNaN(angkatan) ? 0 : angkatan,
+      codeRule: finalCodeRule,
+      codeSource: finalCodeSource,
+      status: finalStatus,
+      statusMessage: finalStatusMessage,
+      // Track originals for tag revert on edit
+      originalKode: finalDisplayKode,
+      originalCodeRule: finalCodeRule,
+      originalCodeSource: finalCodeSource,
+      selected: finalStatus === 'ok' || finalStatus === 'warning',
+    });
+  }
+
+  return preview;
+}
+
+export function validateAsprakCodeEdit(
+  rowIndex: number,
+  newCode: string,
+  currentRows: PreviewRow[],
+  existingAspraks: ExistingAsprakInfo[],
+  forceOverride: boolean = false
+): PreviewRow[] {
+  const updated = [...currentRows];
+  const row = { ...updated[rowIndex] };
+  const uppercased = newCode.toUpperCase();
+  row.kode = uppercased;
+
+  // ── Tag revert ──
+  if (uppercased === row.originalKode) {
+    row.codeSource = row.originalCodeSource;
+    row.codeRule = row.originalCodeRule;
+  } else {
+    row.codeSource = 'csv';
+    row.codeRule = 'Manual edit';
+  }
+
+  // ── Real-time conflict check ──
+  if (/^[A-Z]{3}$/.test(uppercased)) {
+    const conflictInCSV = updated.some(
+      (r, i) =>
+        i !== rowIndex &&
+        r.kode === uppercased &&
+        r.status !== 'error' &&
+        r.status !== 'duplicate-csv'
+    );
+
+    const conflictInDB = !forceOverride && existingAspraks.some((a) => {
+      if (a.kode.toUpperCase() !== uppercased) return false;
+      const gap = row.angkatan - a.angkatan;
+      return gap < CODE_RECYCLE_YEARS;
+    });
+
+    const preserveError = row.status === 'error' && (row.statusMessage?.includes('NIM') || row.statusMessage?.includes('Nama'));
+    const preserveDuplicateCsv = row.status === 'duplicate-csv';
+
+    if (conflictInCSV) {
+      if (!preserveError && !preserveDuplicateCsv) {
+        row.status = 'warning';
+        row.statusMessage = `Kode "${uppercased}" sudah dipakai row lain di CSV ini`;
+      }
+    } else if (conflictInDB) {
+      if (!preserveError && !preserveDuplicateCsv) {
+        row.status = 'warning';
+        row.statusMessage = `Kode "${uppercased}" sudah dipakai asprak lain di DB (< ${CODE_RECYCLE_YEARS} thn)`;
+      }
+    } else {
+      if (!preserveError && !preserveDuplicateCsv) {
+        row.status = 'ok';
+        row.statusMessage = '';
+      }
+    }
+
+    if (row.status === 'ok' || row.status === 'warning') {
+      if (!row.selected) row.selected = true;
+    } else {
+      row.selected = false;
+    }
+  } else if (uppercased.length > 0 && uppercased.length < 3) {
+    const preserveError = row.status === 'error' && (row.statusMessage?.includes('NIM') || row.statusMessage?.includes('Nama'));
+    const preserveDuplicateCsv = row.status === 'duplicate-csv';
+    if (!preserveError && !preserveDuplicateCsv) {
+        row.status = 'error';
+        row.statusMessage = 'Kode harus 3 huruf';
+    }
+    row.selected = false;
+  } else if (uppercased.length === 0) {
+    const preserveError = row.status === 'error' && (row.statusMessage?.includes('NIM') || row.statusMessage?.includes('Nama'));
+    const preserveDuplicateCsv = row.status === 'duplicate-csv';
+    if (!preserveError && !preserveDuplicateCsv) {
+        row.status = 'error';
+        row.statusMessage = 'Kode tidak boleh kosong';
+    }
+    row.selected = false;
+  }
+
+  updated[rowIndex] = row;
+  return updated;
+}

--- a/src/utils/validation/jadwalValidation.ts
+++ b/src/utils/validation/jadwalValidation.ts
@@ -1,0 +1,177 @@
+import { JadwalPreviewRow } from '@/components/jadwal/JadwalCSVPreview';
+import * as jadwalFetcher from '@/lib/fetchers/jadwalFetcher';
+import { MataKuliah } from '@/types/database';
+
+const VALID_DAYS = ['SENIN', 'SELASA', 'RABU', 'KAMIS', 'JUMAT', 'SABTU'];
+
+export async function validateJadwalConflicts(
+  rows: JadwalPreviewRow[],
+  term: string
+): Promise<JadwalPreviewRow[]> {
+  if (!term) return rows;
+
+  const dbResult = await jadwalFetcher.fetchScheduleForValidation(term);
+  const dbSchedule = dbResult.ok ? dbResult.data || [] : [];
+
+  const getKey = (hari: string, sesi: number | string, ruangan: string, jam: string) =>
+    `${hari}-${sesi}-${jam}-${ruangan}`;
+  const getFullKey = (
+    id_mk: string,
+    kelas: string,
+    hari: string,
+    sesi: number,
+    ruangan: string
+  ) => `${id_mk}-${kelas}-${hari}-${sesi}-${ruangan}`;
+
+  const dbMap = new Map<string, any>();
+  const dbFullMap = new Set<string>();
+
+  dbSchedule.forEach((s: any) => {
+    if (s.ruangan) {
+      dbMap.set(getKey(s.hari, s.sesi, s.ruangan, s.jam || ''), s);
+      dbFullMap.add(getFullKey(s.id_mk.toString(), s.kelas, s.hari, s.sesi, s.ruangan));
+    }
+  });
+
+  const internalMap = new Map<string, number[]>();
+
+  rows.forEach((row, idx) => {
+    if (row.status === 'error' || !row.ruangan) return;
+    const key = getKey(row.hari, row.sesi, row.ruangan, row.jam);
+    if (!internalMap.has(key)) {
+      internalMap.set(key, []);
+    }
+    internalMap.get(key)?.push(idx);
+  });
+
+  return rows.map((row) => {
+    const newRow = { ...row };
+
+    if (newRow.status === 'error') return newRow;
+
+    const fullKey = getFullKey(
+      newRow.id_mk,
+      newRow.kelas,
+      newRow.hari,
+      newRow.sesi,
+      newRow.ruangan || ''
+    );
+    if (dbFullMap.has(fullKey)) {
+      newRow.status = 'error';
+      newRow.statusMessage = 'Duplikat: Jadwal ini sudah ada di database.';
+      newRow.selected = false;
+      return newRow;
+    }
+
+    if (newRow.ruangan) {
+      const isCurrentPJJ = newRow.kelas.toUpperCase().includes('PJJ');
+      const key = getKey(newRow.hari, newRow.sesi, newRow.ruangan, newRow.jam);
+      const conflictingIndices = internalMap.get(key) || [];
+
+      const activeConflicts = conflictingIndices.filter(
+        (idx) => !rows[idx].kelas.toUpperCase().includes('PJJ')
+      );
+
+      if (!isCurrentPJJ && activeConflicts.length > 1) {
+        newRow.status = 'error';
+        newRow.statusMessage = `Tabrakan Internal CSV (Baris ${activeConflicts.map((i) => rows[i].originalRow).join(', ')})`;
+        newRow.selected = false;
+        return newRow;
+      }
+
+      if (dbMap.has(key)) {
+        const existing = dbMap.get(key);
+        const isExistingPJJ = existing.kelas.toUpperCase().includes('PJJ');
+
+        if (!isCurrentPJJ && !isExistingPJJ) {
+          newRow.status = 'error';
+          newRow.statusMessage = `Tabrakan Database: Ruangan ${newRow.ruangan} dipakai ${existing.mata_kuliah?.nama_lengkap || 'MK lain'} (${existing.kelas})`;
+          newRow.selected = false;
+          return newRow;
+        }
+      }
+    }
+
+    return newRow;
+  });
+}
+
+export function buildJadwalPreviewRows(
+  data: any[],
+  mataKuliahList: any[],
+  term?: string
+): JadwalPreviewRow[] {
+  const preview: JadwalPreviewRow[] = [];
+
+  const candidates = term
+    ? mataKuliahList.filter((mk) => mk.praktikum?.tahun_ajaran === term)
+    : mataKuliahList;
+
+  data.forEach((row: any) => {
+    const mkName = (row.nama_singkat || row['Nama Singkat'] || row.mata_kuliah || '').trim();
+    const kelas = (row.kelas || row.Kelas || '').trim();
+    const isPJJ = kelas.toUpperCase().includes('PJJ');
+    const prodi = kelas.split('-')[0].toUpperCase();
+
+    const findMk = (searchProdi: string) => {
+      return candidates.find(
+        (mk: any) =>
+          (mk.praktikum?.nama?.toLowerCase() === mkName.toLowerCase() ||
+            mk.nama_lengkap.toLowerCase() === mkName.toLowerCase()) &&
+          mk.program_studi?.toUpperCase() === searchProdi.toUpperCase()
+      );
+    };
+
+    let targetMK = findMk(prodi);
+    if (!targetMK && isPJJ) targetMK = findMk('IF-PJJ');
+    if (!targetMK) targetMK = findMk('IF') || findMk('SE') || findMk('IT') || findMk('DS');
+
+    const mkId = targetMK?.id.toString() || '';
+
+    const hari = (row.hari || row.Hari || '').trim().toUpperCase();
+    const isValidDay = VALID_DAYS.includes(hari);
+
+    const sesi = Number(row.sesi || row.Sesi || 0);
+    const totalAsprak = Number(row.total_asprak || row['Total Asprak'] || 0);
+
+    const displayMkName = targetMK ? targetMK.nama_lengkap : mkName;
+
+    let status: 'ok' | 'error' | 'warning' = 'ok';
+    let statusMessage = '';
+
+    if (!targetMK) {
+      status = 'error';
+      statusMessage = `Mata Kuliah "${mkName}" tidak ditemukan.`;
+    } else if (!isValidDay) {
+      status = 'error';
+      statusMessage = `Hari "${hari}" tidak valid.`;
+    } else if (!isPJJ && sesi <= 0) {
+      status = 'error';
+      statusMessage = 'Sesi harus > 0 (Kecuali PJJ)';
+    }
+
+    let ruanganClean = (row.ruangan || row.Ruangan || '').trim();
+    if (ruanganClean.includes('&')) {
+      ruanganClean = ruanganClean.split('&')[0].trim();
+    }
+
+    preview.push({
+      id_mk: mkId,
+      kelas: kelas,
+      hari: hari,
+      sesi: sesi,
+      jam: (row.jam || row.Jam || '').trim(),
+      ruangan: ruanganClean,
+      total_asprak: totalAsprak,
+      dosen: (row.dosen || row.Dosen || '').trim(),
+      mkName: displayMkName,
+      fromSystemLogic: !!targetMK,
+      status,
+      statusMessage,
+      selected: status === 'ok',
+      originalRow: preview.length + 2,
+    });
+  });
+
+  return preview;
+}

--- a/src/utils/validation/mataKuliahValidation.ts
+++ b/src/utils/validation/mataKuliahValidation.ts
@@ -1,0 +1,73 @@
+import { MataKuliahCSVRow } from '@/components/mata-kuliah/MataKuliahCSVPreview';
+import type { MataKuliahGrouped } from '@/services/mataKuliahService';
+
+export function validateMataKuliahData(
+  data: any[],
+  localValidPraktikums: { id: string; nama: string }[],
+  existingMataKuliah: MataKuliahGrouped[]
+): MataKuliahCSVRow[] {
+  const isValidProdi = (prodi: string) => {
+    const base = prodi?.replace('-PJJ', '') || '';
+    return ['IF', 'IT', 'SE', 'DS'].includes(base);
+  };
+
+  const internalMap = new Set<string>();
+
+  return data.map((r: any) => {
+    // Fallbacks for different header formats (e.g. from template vs random casing)
+    const mk_singkat = (r.mk_singkat || r['Nama Singkat'] || r.nama_singkat || r['MK Singkat'] || '').toString().trim();
+    const nama_lengkap = (r.nama_lengkap || r['Nama Lengkap'] || '').toString().trim();
+    const program_studi = (r.program_studi || r['Program Studi'] || r.prodi || r.Prodi || '').toString().trim().toUpperCase();
+    const dosen_koor = (r.dosen_koor || r['Dosen Koor'] || r.koor || '').toString().trim().toUpperCase();
+
+    // Use localValidPraktikums for validation
+    const isMkKnown = localValidPraktikums.some((p) => p.nama.toUpperCase() === mk_singkat.toUpperCase());
+    const isProdiValid = isValidProdi(program_studi);
+    const isKoorValid = dosen_koor.length === 3;
+
+    let status: 'ok' | 'warning' | 'error' = 'ok';
+    let statusMessage = '';
+
+    const key = `${mk_singkat.toUpperCase()}|${program_studi.toUpperCase()}`;
+
+    // Check Duplicates
+    // existingMataKuliah is grouped by mk_singkat
+    const existingGroup = existingMataKuliah.find((g) => g.mk_singkat.toUpperCase() === mk_singkat.toUpperCase());
+    const isDuplicate = existingGroup?.items.some(
+      (item) => item.program_studi.toUpperCase() === program_studi.toUpperCase()
+    );
+
+    if (isDuplicate) {
+      status = 'error';
+      statusMessage = 'Data Duplikat di Database';
+    } else if (internalMap.has(key)) {
+      status = 'error';
+      statusMessage = 'Duplikat dalam file csv/excel';
+    } else if (!isKoorValid || !isProdiValid) {
+      status = 'error';
+      statusMessage = 'Data Tidak Valid (Prodi/Dosen)';
+    } else if (!isMkKnown) {
+      // Allow unknown MK - it will be created automatically by backend
+      status = 'ok';
+      statusMessage = 'Praktikum baru akan dibuat otomatis';
+    } else if (!mk_singkat || !nama_lengkap) {
+      status = 'error';
+      statusMessage = 'Field Wajib Kurang';
+    }
+
+    if (mk_singkat && program_studi) {
+        internalMap.add(key);
+    }
+
+    return {
+      mk_singkat,
+      nama_lengkap,
+      program_studi,
+      dosen_koor,
+      status,
+      statusMessage,
+      originalMkSingkat: mk_singkat,
+      selected: status !== 'error', // Default select valid rows
+    };
+  });
+}

--- a/src/utils/validation/plottingValidation.ts
+++ b/src/utils/validation/plottingValidation.ts
@@ -1,0 +1,74 @@
+import { PlottingPreviewRow } from '@/components/plotting/PlottingCSVPreview';
+
+export type ExtendedPreviewRow = PlottingPreviewRow & {
+  asprakId?: string;
+  praktikumId?: string;
+};
+
+export function mapPlottingValidationResponse(data: any): ExtendedPreviewRow[] {
+  const { validRows, ambiguousRows, invalidRows } = data;
+
+  const mapped: ExtendedPreviewRow[] = [];
+  let idx = 0;
+
+  // Valid
+  validRows?.forEach((r: any) => {
+    mapped.push({
+      index: idx++,
+      kode_asprak: r.original?.kode_asprak || '???',
+      mk_singkat: r.original?.mk_singkat || '???',
+      status: 'valid',
+      selected: true,
+      asprakId: r.asprak_id,
+      praktikumId: r.praktikum_id,
+    });
+  });
+
+  // Ambiguous
+  ambiguousRows?.forEach((r: any) => {
+    mapped.push({
+      index: idx++,
+      kode_asprak: r.original.kode_asprak,
+      mk_singkat: r.original.mk_singkat,
+      status: 'ambiguous',
+      message: r.reason,
+      candidates: r.candidates,
+      selected: true, // Selected by default, but no candidates selected yet
+      selectedCandidateIds: [], // Empty initially
+      praktikumId: r.praktikum_id,
+    });
+  });
+
+  // Invalid
+  invalidRows?.forEach((r: any) => {
+    mapped.push({
+      index: idx++,
+      kode_asprak: r.original.kode_asprak,
+      mk_singkat: r.original.mk_singkat,
+      status: 'invalid',
+      message: r.reason,
+      selected: false,
+    });
+  });
+
+  return mapped;
+}
+
+export function handlePlottingResolve(
+  index: number,
+  candidateId: string,
+  currentRows: ExtendedPreviewRow[]
+): ExtendedPreviewRow[] {
+  const update = [...currentRows];
+  const row = { ...update[index] };
+
+  const currentIds = row.selectedCandidateIds || [];
+  if (currentIds.includes(candidateId)) {
+    row.selectedCandidateIds = currentIds.filter((id: string) => id !== candidateId);
+  } else {
+    row.selectedCandidateIds = [...currentIds, candidateId];
+  }
+
+  update[index] = row;
+  return update;
+}

--- a/src/utils/validation/praktikumValidation.ts
+++ b/src/utils/validation/praktikumValidation.ts
@@ -1,0 +1,70 @@
+import { PraktikumPreviewRow } from '@/components/praktikum/PraktikumCSVPreview';
+
+export function validatePraktikumData(
+  data: any[],
+  existingPraktikums: { nama: string; tahun_ajaran: string }[]
+): PraktikumPreviewRow[] {
+  const preview: PraktikumPreviewRow[] = [];
+
+  // Create a fast lookup map for existing praktikums
+  const existingMap = new Set(
+    existingPraktikums.map((p) => `${p.nama.toUpperCase()}|${p.tahun_ajaran}`)
+  );
+
+  // We also need to keep track of duplicates within the CSV itself
+  const internalMap = new Set<string>();
+
+  data.forEach((row: any) => {
+    // Allow flexible column names (from Excel sheets or CSV)
+    const nama = (
+      row.nama_singkat ||
+      row.nama_lengkap ||
+      row.nama ||
+      row.Nama ||
+      row['Nama Singkat'] ||
+      ''
+    ).toString().trim().toUpperCase();
+    const tahunAjaran = (row.tahun_ajaran || row['Tahun Ajaran'] || '').toString().trim();
+
+    let status: PraktikumPreviewRow['status'] = 'ok';
+    let statusMessage = '';
+    let selected = true;
+
+    if (!nama) {
+      status = 'error';
+      statusMessage = 'Nama kosong';
+      selected = false;
+    } else if (!tahunAjaran) {
+      status = 'error';
+      statusMessage = 'Tahun Ajaran kosong';
+      selected = false;
+    } else {
+      const key = `${nama}|${tahunAjaran}`;
+
+      // Check against database
+      if (existingMap.has(key)) {
+        status = 'skipped';
+        statusMessage = 'Sudah ada di database';
+        selected = false;
+      }
+      // Check against earlier rows in the same file
+      else if (internalMap.has(key)) {
+        status = 'skipped';
+        statusMessage = 'Duplikat dalam file csv/excel';
+        selected = false;
+      }
+
+      internalMap.add(key);
+    }
+
+    preview.push({
+      nama,
+      tahun_ajaran: tahunAjaran,
+      status,
+      statusMessage,
+      selected,
+    });
+  });
+
+  return preview;
+}


### PR DESCRIPTION
Introduce a multi-step Excel import wizard and strengthen asprak import/edit validation. The pengaturan page now parses Excel client-side and walks through steps (Praktikum, MataKuliah, Asprak, Plotting, Jadwal) using new Step* components. Asprak CSV import and edit flows gain a "force override" option with confirmation, plus improved code conflict checks (angkatan gap / recycle years) and client-side validation moved into new validator utilities. The asprak API route now accepts forceOverride for update operations. Also added a Jadwal CSV preview component and various UI updates (Switch, labels, progress handling) and small service/fetcher adjustments to support the new wizard flow.