### PR TITLE
feat: improve asprak management UX and schedule display

### DIFF
--- a/src/app/(dashboard)/asprak/page.tsx
+++ b/src/app/(dashboard)/asprak/page.tsx
@@ -69,7 +69,6 @@ function AsprakPageContent() {
   const [showImportModal, setShowImportModal] = useState(false);
   const [showPlottingImportModal, setShowPlottingImportModal] = useState(false);
   const [showExportModal, setShowExportModal] = useState(false);
-  const [isEditMode, setIsEditMode] = useState(false);
 
   const [showEditModal, setShowEditModal] = useState(false);
   const [editTarget, setEditTarget] = useState<{ asprak: Asprak; assignments: string[] } | null>(
@@ -281,19 +280,6 @@ function AsprakPageContent() {
             <Download size={18} />
             Export Data
           </Button>
-          <Button
-            variant={isEditMode ? 'secondary' : 'ghost'}
-            size="icon"
-            onClick={() => setIsEditMode(!isEditMode)}
-            className={
-              isEditMode
-                ? 'bg-amber-100 text-amber-600 hover:bg-amber-200'
-                : 'text-muted-foreground'
-            }
-            title={isEditMode ? 'Keluar Mode Edit' : 'Aktifkan Mode Edit'}
-          >
-            {isEditMode ? <X size={20} /> : <Pencil size={20} />}
-          </Button>
         </div>
       </div>
 
@@ -313,9 +299,6 @@ function AsprakPageContent() {
               data={filteredList}
               loading={loading}
               onViewDetails={handleView}
-              isEditMode={isEditMode}
-              onEdit={handleEditAsprak}
-              onDelete={handleDeleteClick}
             />
           </div>
         </TabsContent>
@@ -366,6 +349,8 @@ function AsprakPageContent() {
         <AsprakDetailsModal
           asprak={selectedAsprak}
           loading={loadingDetails}
+          onEdit={handleEditAsprak}
+          onDelete={handleDeleteClick}
           onClose={closeDetails}
           open={!!selectedAsprak}
         />

--- a/src/app/(dashboard)/jadwal/page.tsx
+++ b/src/app/(dashboard)/jadwal/page.tsx
@@ -289,8 +289,10 @@ export default function JadwalPage() {
       >();
 
       staticForDay.forEach((s) => {
-        const rowKey = s.sesi !== null && s.sesi !== undefined ? s.sesi.toString() : s.jam;
-        sessionsAsKeys.set(rowKey, { sesi: s.sesi, jam: s.jam, rowKey });
+        if (s.sesi !== 5) {
+          const rowKey = s.sesi !== null && s.sesi !== undefined ? s.sesi.toString() : s.jam;
+          sessionsAsKeys.set(rowKey, { sesi: s.sesi, jam: s.jam, rowKey });
+        }
       });
 
       const daySchedules = jadwalList.filter((j) => j.hari?.toUpperCase() === day);
@@ -529,7 +531,7 @@ export default function JadwalPage() {
                                       {jadwal.kelas}
                                     </div>
                                     <div className="text-[8px] sm:text-[9px] text-white/80 truncate px-1">
-                                      {(jadwal.dosen || '-').split(' ')[0]}
+                                      {jadwal.total_asprak || 0} asprak
                                     </div>
                                   </div>
                                 </div>

--- a/src/app/(dashboard)/mata-kuliah/page.tsx
+++ b/src/app/(dashboard)/mata-kuliah/page.tsx
@@ -13,7 +13,7 @@ import MataKuliahManualModal from '@/components/mata-kuliah/MataKuliahManualModa
 import { toast } from 'sonner';
 
 function MataKuliahPageContent() {
-  const { terms, selectedTerm, setSelectedTerm } = useAsprak();
+  const { terms, selectedTerm, setSelectedTerm } = useAsprak(undefined, true);
   const { getMataKuliahByTerm, createMataKuliah, bulkImportMataKuliah, loading } = useMataKuliah();
   const { getPraktikumByTerm } = usePraktikum();
 
@@ -26,6 +26,7 @@ function MataKuliahPageContent() {
 
   useEffect(() => {
     async function fetchData() {
+      if (!selectedTerm) return;
       try {
         const [mkData, praktikumData] = await Promise.all([
           getMataKuliahByTerm(selectedTerm),

--- a/src/app/(dashboard)/praktikum/page.tsx
+++ b/src/app/(dashboard)/praktikum/page.tsx
@@ -17,7 +17,7 @@ import PraktikumDetailsModal from '@/components/praktikum/PraktikumDetailsModal'
 import { PraktikumWithStats } from '@/services/praktikumService';
 
 function PraktikumPageContent() {
-  const { terms, selectedTerm, setSelectedTerm } = useAsprak();
+  const { terms, selectedTerm, setSelectedTerm } = useAsprak(undefined, true);
   const { getPraktikumByTerm, bulkImport, getOrCreate, loading: praktikumLoading } = usePraktikum();
 
   const [praktikumList, setPraktikumList] = useState<PraktikumWithStats[]>([]);
@@ -29,7 +29,7 @@ function PraktikumPageContent() {
 
   useEffect(() => {
     async function fetchPraktikums() {
-      if (selectedTerm === undefined) return;
+      if (!selectedTerm) return;
 
       setLoadingList(true);
       const data = await getPraktikumByTerm(selectedTerm);
@@ -117,6 +117,7 @@ function PraktikumPageContent() {
           selectedTerm={selectedTerm}
           onTermChange={setSelectedTerm}
           hideSearch={true}
+          hideAllOption={true}
         />
 
         <div className="mt-6">

--- a/src/components/asprak/AsprakCSVPreview.tsx
+++ b/src/components/asprak/AsprakCSVPreview.tsx
@@ -68,8 +68,8 @@ export default function AsprakCSVPreview({
   const totalManualEdit = rows.filter((r) => r.codeRule === 'Manual edit' && (r.status === 'ok' || r.status === 'warning')).length;
   const totalFromCSV = rows.filter((r) => r.codeSource === 'csv' && r.codeRule !== 'Manual edit' && r.status === 'ok').length;
   
-  // Count selectable rows (OK or Warning)
-  const selectableRows = rows.filter(r => r.status === 'ok' || r.status === 'warning');
+  // Count selectable rows (OK)
+  const selectableRows = rows.filter(r => r.status === 'ok');
   const selectedCount = selectableRows.filter(r => r.selected).length;
   const allSelected = selectableRows.length > 0 && selectedCount === selectableRows.length;
   const isIndeterminate = selectedCount > 0 && selectedCount < selectableRows.length;
@@ -195,7 +195,7 @@ export default function AsprakCSVPreview({
                 const isDuplicateDB = row.status === 'error' && row.statusMessage?.includes('Duplikat');
                 const isDuplicateCSV = row.status === 'duplicate-csv';
                 const isDuplicate = isDuplicateDB || isDuplicateCSV;
-                const isDisabled = row.status === 'error' || row.status === 'duplicate-csv';
+                const isDisabled = row.status === 'error' || row.status === 'duplicate-csv' || row.status === 'warning';
                 
                 return (
                 <tr
@@ -205,14 +205,14 @@ export default function AsprakCSVPreview({
                     ${isDuplicateDB ? 'bg-red-500/10' : ''}
                     ${isDuplicateCSV ? 'bg-orange-500/10' : ''}
                     ${row.status === 'error' && !isDuplicate ? 'bg-red-500/5' : ''}
-                    ${row.status === 'warning' ? 'bg-amber-500/5' : ''}
+                    ${row.status === 'warning' ? 'bg-amber-500/10 opacity-75' : ''}
                     ${!isDisabled && row.selected ? 'bg-muted/40' : ''}
                     hover:bg-muted/60
                   `}
                 >
                   <td className="px-3 py-2 text-center">
                     <Checkbox 
-                      checked={row.selected}
+                      checked={row.selected && !isDisabled}
                       onCheckedChange={() => onToggleSelect(idx)}
                       disabled={isDisabled}
                       className={isDisabled ? "opacity-50 cursor-not-allowed" : ""}

--- a/src/components/asprak/AsprakDetailsModal.tsx
+++ b/src/components/asprak/AsprakDetailsModal.tsx
@@ -4,6 +4,8 @@ import { useMemo } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Badge } from '@/components/ui/badge';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import { Button } from '@/components/ui/button';
+import { Pencil, Trash } from 'lucide-react';
 
 interface AsprakWithAssignments extends Asprak {
   assignments?: AsprakAssignment[];
@@ -12,6 +14,8 @@ interface AsprakWithAssignments extends Asprak {
 interface AsprakDetailsModalProps {
   asprak: AsprakWithAssignments;
   loading: boolean;
+  onEdit: (asprak: Asprak) => void;
+  onDelete: (asprak: Asprak) => void;
   onClose: () => void;
   open: boolean;
 }
@@ -19,6 +23,8 @@ interface AsprakDetailsModalProps {
 export default function AsprakDetailsModal({
   asprak,
   loading,
+  onEdit,
+  onDelete,
   onClose,
   open,
 }: AsprakDetailsModalProps) {
@@ -96,6 +102,32 @@ export default function AsprakDetailsModal({
               </div>
             </div>
           </ScrollArea>
+          <div className="border-t px-6 py-4 bg-muted/10 flex justify-between items-center rounded-b-lg">
+            <Button
+              variant="destructive"
+              onClick={() => {
+                onClose();
+                onDelete(asprak);
+              }}
+            >
+              <Trash size={16} className="mr-2" />
+              Hapus
+            </Button>
+            <div className="flex gap-2 items-center">
+              <Button variant="outline" onClick={onClose}>
+                Tutup
+              </Button>
+              <Button
+                onClick={() => {
+                  onClose();
+                  onEdit(asprak);
+                }}
+              >
+                <Pencil size={16} className="mr-2" />
+                Edit
+              </Button>
+            </div>
+          </div>
         </DialogHeader>
       </DialogContent>
     </Dialog>

--- a/src/components/asprak/AsprakFilters.tsx
+++ b/src/components/asprak/AsprakFilters.tsx
@@ -16,6 +16,7 @@ interface AsprakFiltersProps {
   selectedTerm: string;
   onTermChange: (term: string) => void;
   hideSearch?: boolean;
+  hideAllOption?: boolean;
 }
 
 export default function AsprakFilters({
@@ -25,6 +26,7 @@ export default function AsprakFilters({
   selectedTerm,
   onTermChange,
   hideSearch = false,
+  hideAllOption = false,
 }: AsprakFiltersProps) {
   return (
     <div className={`flex flex-col sm:flex-row gap-4 border-border items-center ${hideSearch ? 'justify-end' : ''}`}>
@@ -51,7 +53,7 @@ export default function AsprakFilters({
           </SelectTrigger>
           <SelectContent>
             <SelectGroup>
-              <SelectItem value="all">Semua Angkatan</SelectItem>
+              {!hideAllOption && <SelectItem value="all">Semua Angkatan</SelectItem>}
               {terms.map((term) => (
                 <SelectItem key={term} value={term}>
                   {term}

--- a/src/components/asprak/AsprakImportCSVModal.tsx
+++ b/src/components/asprak/AsprakImportCSVModal.tsx
@@ -176,7 +176,7 @@ export default function AsprakImportCSVModal({
       const updated = [...prev];
       const row = { ...updated[rowIndex] };
       // Only toggle if not disabled
-      if (row.status !== 'error' && row.status !== 'duplicate-csv') {
+      if (row.status !== 'error' && row.status !== 'duplicate-csv' && row.status !== 'warning') {
         row.selected = !row.selected;
         updated[rowIndex] = row;
       }
@@ -188,7 +188,7 @@ export default function AsprakImportCSVModal({
     setPreviewRows((prev) => {
       return prev.map((row) => {
         // Only modify selectable rows
-        if (row.status !== 'error' && row.status !== 'duplicate-csv') {
+        if (row.status !== 'error' && row.status !== 'duplicate-csv' && row.status !== 'warning') {
           return { ...row, selected: checked };
         }
         return row;

--- a/src/components/asprak/AsprakTable.tsx
+++ b/src/components/asprak/AsprakTable.tsx
@@ -8,7 +8,7 @@ import {
   flexRender,
   ColumnDef,
 } from '@tanstack/react-table';
-import { ArrowUpRight, ChevronLeft, ChevronRight, Pencil, Trash, X } from 'lucide-react';
+import { ArrowUpRight, ChevronLeft, ChevronRight } from 'lucide-react';
 import { Asprak } from '@/types/database';
 import {
   Table,
@@ -34,18 +34,12 @@ interface AsprakTableProps {
   data: Asprak[];
   loading: boolean;
   onViewDetails: (asprak: Asprak) => void;
-  isEditMode?: boolean;
-  onEdit?: (asprak: Asprak) => void;
-  onDelete?: (asprak: Asprak) => void;
 }
 
 export default function AsprakTable({
   data,
   loading,
   onViewDetails,
-  isEditMode = false,
-  onEdit,
-  onDelete,
 }: AsprakTableProps) {
   const columns = useMemo<ColumnDef<Asprak>[]>(
     () => [
@@ -70,36 +64,13 @@ export default function AsprakTable({
         id: 'actions',
         header: 'Aksi',
         cell: ({ row }) => (
-          isEditMode ? (
-            <div className="flex items-center gap-2">
-              <Button
-                variant="outline"
-                size="icon"
-                className="h-8 w-8 text-amber-500 hover:text-amber-600 hover:bg-amber-50"
-                onClick={() => onEdit?.(row.original)}
-                title="Edit"
-              >
-                <Pencil size={14} />
-              </Button>
-              <Button
-                variant="outline"
-                size="icon"
-                className="h-8 w-8 text-destructive hover:text-destructive hover:bg-destructive/10"
-                onClick={() => onDelete?.(row.original)}
-                title="Hapus"
-              >
-                <Trash size={14} />
-              </Button>
-            </div>
-          ) : (
             <Button variant="ghost" size="sm" onClick={() => onViewDetails(row.original)}>
               Lihat <ArrowUpRight className="ml-1" size={14} />
             </Button>
-          )
         ),
       },
     ],
-    [onViewDetails, isEditMode, onEdit, onDelete]
+    [onViewDetails]
   );
 
   const table = useReactTable({

--- a/src/hooks/useAsprak.ts
+++ b/src/hooks/useAsprak.ts
@@ -9,27 +9,38 @@ import { useState, useEffect, useCallback } from 'react';
 import { Asprak } from '@/types/database';
 import * as asprakFetcher from '@/lib/fetchers/asprakFetcher';
 
-export function useAsprak(initialTerm?: string) {
+export function useAsprak(initialTerm?: string, defaultToLatest: boolean = false) {
   const [data, setData] = useState<Asprak[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   const [terms, setTerms] = useState<string[]>([]);
-  const [selectedTerm, setSelectedTerm] = useState(initialTerm || 'all');
+  const [selectedTerm, setSelectedTerm] = useState(initialTerm || (defaultToLatest ? '' : 'all'));
+  const [hasInitializedLatest, setHasInitializedLatest] = useState(false);
 
   const fetchTerms = useCallback(async () => {
     const result = await asprakFetcher.fetchAvailableTerms();
     if (result.ok && result.data) {
       setTerms(result.data);
+      if (defaultToLatest && !hasInitializedLatest && result.data.length > 0) {
+        setSelectedTerm(result.data[0]);
+        setHasInitializedLatest(true);
+      }
     }
-  }, [selectedTerm, initialTerm]);
+  }, [defaultToLatest, hasInitializedLatest]);
 
   const fetchAll = useCallback(async () => {
     setLoading(true);
     setError(null);
 
-    // If "all" is selected, pass undefined to fetch all
-    const termToFetch = selectedTerm === 'all' ? undefined : selectedTerm;
+    // If "all" or empty (waiting for latest) is selected, pass undefined or handle appropriately.
+    // We shouldn't fetch asprak if we're still waiting for the latest term initialization
+    if (defaultToLatest && !hasInitializedLatest) {
+      setLoading(false);
+      return;
+    }
+
+    const termToFetch = selectedTerm === 'all' || selectedTerm === '' ? undefined : selectedTerm;
     const result = await asprakFetcher.fetchAllAsprak(termToFetch);
 
     if (result.ok) {

--- a/src/utils/validation/asprakValidation.ts
+++ b/src/utils/validation/asprakValidation.ts
@@ -129,7 +129,7 @@ export function validateAsprakData(
       originalKode: finalDisplayKode,
       originalCodeRule: finalCodeRule,
       originalCodeSource: finalCodeSource,
-      selected: finalStatus === 'ok' || finalStatus === 'warning',
+      selected: finalStatus === 'ok',
     });
   }
 
@@ -193,7 +193,7 @@ export function validateAsprakCodeEdit(
       }
     }
 
-    if (row.status === 'ok' || row.status === 'warning') {
+    if (row.status === 'ok') {
       if (!row.selected) row.selected = true;
     } else {
       row.selected = false;


### PR DESCRIPTION
- Update Jadwal UI to dynamically hide Sesi 5 if empty and show total asprak
- Disable checkboxes for 'warning' rows in Asprak CSV import
- Move Asprak edit & delete actions into the Details Modal
- Set Praktikum & Mata Kuliah term dropdowns to default to the latest term
- Fix initial data load bug on term filters