### PR TITLE
fix (jadwal): Use is_pengganti property in schedule payload

### DIFF
--- a/src/services/jadwalService.ts
+++ b/src/services/jadwalService.ts
@@ -169,7 +169,7 @@ export async function getTodaySchedule(
         ruangan: p.ruangan,
         tanggal: p.tanggal,
         modul: p.modul,
-        __is_pengganti: true,
+        is_pengganti: true,
       });
     });
   }


### PR DESCRIPTION
Replace `__is_pengganti` with `is_pengganti` in the object constructed by getTodaySchedule. This aligns the payload with the expected property name (removing the accidental double underscore) so substitute schedule filtering/behavior works correctly.