### PR TITLE
feat(asprak) : Show code availability with colored states

### DIFF
--- a/src/app/(dashboard)/asprak/AsprakClientPage.tsx
+++ b/src/app/(dashboard)/asprak/AsprakClientPage.tsx
@@ -346,7 +346,7 @@ export default function AsprakClientPage({
 
       <div className="w-full">
         {activeTab === 'rules' ? (
-          <AsprakGenerationRules />
+          <AsprakGenerationRules existingCodes={existingCodes} />
         ) : (
           <div className="card glass p-6 flex flex-col gap-6 border border-border/50">
             <AsprakFilters

--- a/src/components/asprak/AsprakGenerationRules.tsx
+++ b/src/components/asprak/AsprakGenerationRules.tsx
@@ -21,7 +21,33 @@ import {
   generateFullCandidates,
 } from '@/utils/asprakCodeGenerator';
 
-export default function AsprakGenerationRules() {
+interface AsprakGenerationRulesProps {
+  existingCodes?: string[];
+}
+
+export default function AsprakGenerationRules({ existingCodes = [] }: AsprakGenerationRulesProps) {
+  const getCodeStatus = (code: string | null, index: number, allCodes: (string | null)[]) => {
+    if (!code) return 'none';
+    if (existingCodes.includes(code)) return 'taken';
+    const firstAvailableIdx = allCodes.findIndex((c) => c && !existingCodes.includes(c));
+    if (firstAvailableIdx === index) return 'chosen';
+    return 'available';
+  };
+
+  const renderCodeSpan = (code: string | null, index: number, allCodes: (string | null)[]) => {
+    const status = getCodeStatus(code, index, allCodes);
+    if (!code || status === 'none') {
+      return <span className="font-mono text-muted-foreground">N/A</span>;
+    }
+    if (status === 'taken') {
+      return <span className="font-mono font-bold text-red-500">{code}</span>;
+    }
+    if (status === 'chosen') {
+      return <span className="font-mono font-bold text-blue-600 dark:text-blue-400">{code}</span>;
+    }
+    return <span className="font-mono font-bold text-green-600 dark:text-green-500">{code}</span>;
+  };
+
   const [name1, setName1] = useState('BUDI');
   const [name2, setName2] = useState('ANDI WIJAYA');
   const [name3, setName3] = useState('MUHAMMAD ABIYU ALGHIFARI');
@@ -102,22 +128,22 @@ export default function AsprakGenerationRules() {
                 <TableRow>
                   <TableCell className="font-mono text-xs">1.1</TableCell>
                   <TableCell>3 huruf pertama</TableCell>
-                  <TableCell className="font-mono font-bold">{codes1[0] || 'N/A'}</TableCell>
+                  <TableCell>{renderCodeSpan(codes1[0], 0, codes1)}</TableCell>
                 </TableRow>
                 <TableRow>
                   <TableCell className="font-mono text-xs">1.2</TableCell>
                   <TableCell>Huruf ke-1, 2, 4</TableCell>
-                  <TableCell className="font-mono font-bold">{codes1[1] || 'N/A'}</TableCell>
+                  <TableCell>{renderCodeSpan(codes1[1], 1, codes1)}</TableCell>
                 </TableRow>
                 <TableRow>
                   <TableCell className="font-mono text-xs">1.3</TableCell>
                   <TableCell>Huruf ke-1, 3, 4</TableCell>
-                  <TableCell className="font-mono font-bold">{codes1[2] || 'N/A'}</TableCell>
+                  <TableCell>{renderCodeSpan(codes1[2], 2, codes1)}</TableCell>
                 </TableRow>
                 <TableRow>
                   <TableCell className="font-mono text-xs">1.4</TableCell>
                   <TableCell>Huruf ke-1, 2, Akhir</TableCell>
-                  <TableCell className="font-mono font-bold">{codes1[3] || 'N/A'}</TableCell>
+                  <TableCell>{renderCodeSpan(codes1[3], 3, codes1)}</TableCell>
                 </TableRow>
               </TableBody>
             </Table>
@@ -159,22 +185,22 @@ export default function AsprakGenerationRules() {
                 <TableRow>
                   <TableCell className="font-mono text-xs">2.1</TableCell>
                   <TableCell>Huruf 1,2(K1) + Huruf 1(K2)</TableCell>
-                  <TableCell className="font-mono font-bold">{codes2[0] || 'N/A'}</TableCell>
+                  <TableCell>{renderCodeSpan(codes2[0], 0, codes2)}</TableCell>
                 </TableRow>
                 <TableRow>
                   <TableCell className="font-mono text-xs">2.2</TableCell>
                   <TableCell>Huruf 1(K1) + Huruf 1,2(K2)</TableCell>
-                  <TableCell className="font-mono font-bold">{codes2[1] || 'N/A'}</TableCell>
+                  <TableCell>{renderCodeSpan(codes2[1], 1, codes2)}</TableCell>
                 </TableRow>
                 <TableRow>
                   <TableCell className="font-mono text-xs">2.3</TableCell>
                   <TableCell>Huruf 1(K1) + Huruf 1(K2) + Akhir(K2)</TableCell>
-                  <TableCell className="font-mono font-bold">{codes2[2] || 'N/A'}</TableCell>
+                  <TableCell>{renderCodeSpan(codes2[2], 2, codes2)}</TableCell>
                 </TableRow>
                 <TableRow>
                   <TableCell className="font-mono text-xs">2.4</TableCell>
                   <TableCell>Huruf 1,2(K1) + Akhir(K2)</TableCell>
-                  <TableCell className="font-mono font-bold">{codes2[3] || 'N/A'}</TableCell>
+                  <TableCell>{renderCodeSpan(codes2[3], 3, codes2)}</TableCell>
                 </TableRow>
               </TableBody>
             </Table>
@@ -226,22 +252,22 @@ export default function AsprakGenerationRules() {
                   <TableRow>
                     <TableCell className="font-mono text-xs">3.1</TableCell>
                     <TableCell>Huruf pertama tiap kata (3 kata awal)</TableCell>
-                    <TableCell className="font-mono font-bold">{codes3[0] || 'N/A'}</TableCell>
+                    <TableCell>{renderCodeSpan(codes3[0], 0, codes3)}</TableCell>
                   </TableRow>
                   <TableRow>
                     <TableCell className="font-mono text-xs">3.2</TableCell>
                     <TableCell>Huruf 1(K1) + Huruf 1,2(K2)</TableCell>
-                    <TableCell className="font-mono font-bold">{codes3[1] || 'N/A'}</TableCell>
+                    <TableCell>{renderCodeSpan(codes3[1], 1, codes3)}</TableCell>
                   </TableRow>
                   <TableRow>
                     <TableCell className="font-mono text-xs">3.3</TableCell>
                     <TableCell>Huruf 1,2(K1) + Huruf 1(K2)</TableCell>
-                    <TableCell className="font-mono font-bold">{codes3[2] || 'N/A'}</TableCell>
+                    <TableCell>{renderCodeSpan(codes3[2], 2, codes3)}</TableCell>
                   </TableRow>
                   <TableRow>
                     <TableCell className="font-mono text-xs">3.4</TableCell>
                     <TableCell>Huruf 1(K1) + Huruf 1(K2) + Huruf 2(K3)</TableCell>
-                    <TableCell className="font-mono font-bold">{codes3[3] || 'N/A'}</TableCell>
+                    <TableCell>{renderCodeSpan(codes3[3], 3, codes3)}</TableCell>
                   </TableRow>
                 </TableBody>
               </Table>
@@ -257,22 +283,22 @@ export default function AsprakGenerationRules() {
                   <TableRow>
                     <TableCell className="font-mono text-xs">3.5</TableCell>
                     <TableCell>Huruf 1(K1) + Huruf 1,2(K3)</TableCell>
-                    <TableCell className="font-mono font-bold">{codes3[4] || 'N/A'}</TableCell>
+                    <TableCell>{renderCodeSpan(codes3[4], 4, codes3)}</TableCell>
                   </TableRow>
                   <TableRow>
                     <TableCell className="font-mono text-xs">3.6</TableCell>
                     <TableCell>Huruf 1,2(K1) + Huruf 1(K3)</TableCell>
-                    <TableCell className="font-mono font-bold">{codes3[5] || 'N/A'}</TableCell>
+                    <TableCell>{renderCodeSpan(codes3[5], 5, codes3)}</TableCell>
                   </TableRow>
                   <TableRow>
                     <TableCell className="font-mono text-xs">3.7</TableCell>
                     <TableCell>Huruf 1(K1) + Huruf 1(K2) + Akhir(K3)</TableCell>
-                    <TableCell className="font-mono font-bold">{codes3[6] || 'N/A'}</TableCell>
+                    <TableCell>{renderCodeSpan(codes3[6], 6, codes3)}</TableCell>
                   </TableRow>
                   <TableRow>
                     <TableCell className="font-mono text-xs">3.8</TableCell>
                     <TableCell>Huruf 1(K1) + Huruf 2(K2) + Huruf 1(K3)</TableCell>
-                    <TableCell className="font-mono font-bold">{codes3[7] || 'N/A'}</TableCell>
+                    <TableCell>{renderCodeSpan(codes3[7], 7, codes3)}</TableCell>
                   </TableRow>
                 </TableBody>
               </Table>
@@ -320,14 +346,35 @@ export default function AsprakGenerationRules() {
                 <ScrollArea className="h-full w-full">
                   <div className="grid grid-cols-4 gap-2">
                     {strategicCandidates.length > 0 ? (
-                      strategicCandidates.map((c) => (
-                        <span
-                          key={c}
-                          className="text-center bg-background px-1 py-0.5 rounded border"
-                        >
-                          {c}
-                        </span>
-                      ))
+                      strategicCandidates.map((c, idx) => {
+                        const status = getCodeStatus(c, idx, strategicCandidates);
+                        let bg = 'bg-background';
+                        let textColor = 'text-foreground';
+                        let border = 'border-border';
+
+                        if (status === 'taken') {
+                          bg = 'bg-red-50 dark:bg-red-950/20';
+                          textColor = 'text-red-500 font-medium line-through decoration-red-500/50';
+                          border = 'border-red-200 dark:border-red-800';
+                        } else if (status === 'chosen') {
+                          bg = 'bg-blue-50 dark:bg-blue-950/20';
+                          textColor = 'text-blue-600 dark:text-blue-400 font-bold';
+                          border = 'border-blue-300 dark:border-blue-700';
+                        } else if (status === 'available') {
+                          bg = 'bg-green-50 dark:bg-green-950/20';
+                          textColor = 'text-green-600 dark:text-green-500 font-medium';
+                          border = 'border-green-200 dark:border-green-800';
+                        }
+
+                        return (
+                          <span
+                            key={c + '-' + idx}
+                            className={`text-center px-1 py-0.5 rounded border ${bg} ${textColor} ${border}`}
+                          >
+                            {c}
+                          </span>
+                        );
+                      })
                     ) : (
                       <span className="text-muted-foreground col-span-4 block text-center py-4">
                         No combinatorics available
@@ -352,14 +399,35 @@ export default function AsprakGenerationRules() {
                 <ScrollArea className="h-full w-full">
                   <div className="grid grid-cols-4 gap-2">
                     {fullCandidates.length > 0 ? (
-                      fullCandidates.map((c) => (
-                        <span
-                          key={c}
-                          className="text-center bg-background px-1 py-0.5 rounded border"
-                        >
-                          {c}
-                        </span>
-                      ))
+                      fullCandidates.map((c, idx) => {
+                        const status = getCodeStatus(c, idx, fullCandidates);
+                        let bg = 'bg-background';
+                        let textColor = 'text-foreground';
+                        let border = 'border-border';
+
+                        if (status === 'taken') {
+                          bg = 'bg-red-50 dark:bg-red-950/20';
+                          textColor = 'text-red-500 font-medium line-through decoration-red-500/50';
+                          border = 'border-red-200 dark:border-red-800';
+                        } else if (status === 'chosen') {
+                          bg = 'bg-blue-50 dark:bg-blue-950/20';
+                          textColor = 'text-blue-600 dark:text-blue-400 font-bold';
+                          border = 'border-blue-300 dark:border-blue-700';
+                        } else if (status === 'available') {
+                          bg = 'bg-green-50 dark:bg-green-950/20';
+                          textColor = 'text-green-600 dark:text-green-500 font-medium';
+                          border = 'border-green-200 dark:border-green-800';
+                        }
+
+                        return (
+                          <span
+                            key={c + '-' + idx}
+                            className={`text-center px-1 py-0.5 rounded border ${bg} ${textColor} ${border}`}
+                          >
+                            {c}
+                          </span>
+                        );
+                      })
                     ) : (
                       <span className="text-muted-foreground col-span-4 block text-center py-4">
                         No combinatorics available
@@ -371,6 +439,28 @@ export default function AsprakGenerationRules() {
             </div>
           </CardContent>
         </Card>
+
+        {/* Legend Warna Hasil */}
+        <div className="md:col-span-2 pt-2 border-t mt-2 pb-6">
+          <h3 className="text-sm font-semibold mb-3">Keterangan Warna Hasil:</h3>
+          <div className="flex flex-wrap gap-4 text-xs font-medium">
+            <div className="flex items-center gap-2 p-2 rounded-md bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-800">
+              <div className="w-3 h-3 rounded-full bg-red-500"></div>
+              <span className="text-red-600 dark:text-red-400">Sudah Dipakai (Konflik)</span>
+            </div>
+            <div className="flex items-center gap-2 p-2 rounded-md bg-blue-50 dark:bg-blue-950/20 border border-blue-300 dark:border-blue-700">
+              <div className="w-3 h-3 rounded-full bg-blue-500"></div>
+              <span className="text-blue-600 dark:text-blue-400">Dimasukkan ke Database (Terpilih/Available)</span>
+            </div>
+            <div className="flex items-center gap-2 p-2 rounded-md bg-green-50 dark:bg-green-950/20 border border-green-200 dark:border-green-800">
+              <div className="w-3 h-3 rounded-full bg-green-500"></div>
+              <span className="text-green-600 dark:text-green-500">Tersedia (Alternatif/Backup)</span>
+            </div>
+          </div>
+          <p className="text-xs text-muted-foreground mt-3 leading-relaxed">
+            Sistem secara otomatis akan memilih kode <span className="font-semibold text-blue-500">warna biru</span> untuk dimasukkan ke database karena merupakan baris kode pertama dari atas yang belum terpakai oleh orang lain.
+          </p>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Pass existingCodes into AsprakGenerationRules and add status logic to mark candidate codes as taken, chosen, available, or none. Introduces getCodeStatus and renderCodeSpan helpers to render styled spans in the rules tables, updates strategic/full candidate grids to use color-coded styles (and unique keys using index), and adds a legend explaining the color meanings. This makes it easy to see conflicts and selected/available backups at a glance.