### PR TITLE
fix (jadwal) : Use WIB timezone for schedule calculations

### DIFF
--- a/src/services/jadwalService.ts
+++ b/src/services/jadwalService.ts
@@ -85,17 +85,20 @@ export async function getTodaySchedule(
   supabaseClient?: SupabaseClient
 ): Promise<Jadwal[]> {
   const supabase = supabaseClient || globalAdmin;
-  const now = new Date();
+  
+  // Force calculations to use WIB (UTC+7) timezone regardless of server locale (e.g. Vercel UTC)
+  const nowUtc = new Date();
+  const nowWib = new Date(nowUtc.getTime() + 7 * 60 * 60 * 1000);
 
-  // 1. Get current day name (SENIN, etc.)
-  const dayIndex = now.getDay();
+  // 1. Get current day name (SENIN, etc.) in WIB
+  const dayIndex = nowWib.getUTCDay();
   const weekdays = ['SENIN', 'SELASA', 'RABU', 'KAMIS', 'JUMAT', 'SABTU'];
   const todayName = dayIndex === 0 ? 'MINGGU' : weekdays[dayIndex - 1];
 
-  // 2. Get today's local date string (YYYY-MM-DD)
-  const year = now.getFullYear();
-  const month = String(now.getMonth() + 1).padStart(2, '0');
-  const day = String(now.getDate()).padStart(2, '0');
+  // 2. Get today's local date string (YYYY-MM-DD) in WIB
+  const year = nowWib.getUTCFullYear();
+  const month = String(nowWib.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(nowWib.getUTCDate()).padStart(2, '0');
   const todayDateStr = `${year}-${month}-${day}`;
 
   // 3. Fetch regular schedules for today


### PR DESCRIPTION
Force schedule date/day computations to use WIB (UTC+7) instead of the server's local time. Introduces nowUtc and nowWib (UTC+7) and switches to UTC-based getters (getUTCDay, getUTCFullYear, getUTCMonth, getUTCDate) to derive the weekday name and YYYY-MM-DD string. Prevents incorrect day/date results on servers running in UTC (e.g., Vercel).