### PR TITLE
fix(jadwal) : Add striped highlight for pengganti schedules

### DIFF
--- a/src/app/(dashboard)/jadwal/JadwalClientPage.tsx
+++ b/src/app/(dashboard)/jadwal/JadwalClientPage.tsx
@@ -413,11 +413,17 @@ export default function JadwalClientPage({
         {/* Legend */}
         <div className="mt-4 flex items-center gap-4 text-xs text-muted-foreground border-t border-border/50 pt-3 px-2">
           <div className="flex items-center gap-1.5">
-            <div className="w-3 h-3 rounded-sm ring-2 ring-inset ring-yellow-400 bg-muted"></div>
+            <div 
+              className="w-4 h-4 bg-muted rounded-[2px]"
+              style={{
+                background: `linear-gradient(var(--muted), var(--muted)) padding-box, repeating-linear-gradient(45deg, #facc15, #facc15 5px, #ffffff 5px, #ffffff 10px) border-box`,
+                border: '3px solid transparent',
+              }}
+            ></div>
             <span>Jadwal Pengganti</span>
           </div>
           <div className="flex items-center gap-1.5">
-            <div className="w-3 h-3 rounded-sm bg-muted border border-border"></div>
+            <div className="w-3.5 h-3.5 rounded-sm bg-muted border border-border"></div>
             <span>Jadwal Reguler</span>
           </div>
         </div>

--- a/src/components/DashboardCharts.tsx
+++ b/src/components/DashboardCharts.tsx
@@ -223,11 +223,17 @@ export default function DashboardCharts({
               {/* Legend */}
               <div className="mt-4 flex items-center gap-4 text-xs text-muted-foreground border-t border-border/50 pt-3">
                 <div className="flex items-center gap-1.5">
-                  <div className="w-3 h-3 rounded-sm ring-2 ring-inset ring-yellow-400 bg-muted"></div>
+                  <div 
+                    className="w-4 h-4 bg-muted rounded-[2px]"
+                    style={{
+                      background: `linear-gradient(var(--muted), var(--muted)) padding-box, repeating-linear-gradient(45deg, #facc15, #facc15 5px, #ffffff 5px, #ffffff 10px) border-box`,
+                      border: '3px solid transparent',
+                    }}
+                  ></div>
                   <span>Jadwal Pengganti</span>
                 </div>
                 <div className="flex items-center gap-1.5">
-                  <div className="w-3 h-3 rounded-sm bg-muted border border-border"></div>
+                  <div className="w-4 h-4 rounded-sm bg-muted border border-border"></div>
                   <span>Jadwal Reguler</span>
                 </div>
               </div>

--- a/src/components/jadwal/ScheduleCell.tsx
+++ b/src/components/jadwal/ScheduleCell.tsx
@@ -18,6 +18,7 @@ export const ScheduleCell: React.FC<ScheduleCellProps> = ({
   showAsprakCount = false,
 }) => {
   const isPengganti = jadwal.is_pengganti;
+  const bgColor = jadwal.mata_kuliah?.warna || getCourseColor(jadwal.mata_kuliah?.nama_lengkap || '');
 
   return (
     <div
@@ -26,11 +27,17 @@ export const ScheduleCell: React.FC<ScheduleCellProps> = ({
         onClick
           ? 'cursor-pointer hover:brightness-110 hover:scale-105 hover:z-20 hover:shadow-lg'
           : ''
-      } ${isPengganti ? 'ring-4 ring-inset ring-yellow-400 z-10' : ''}`}
-      style={{
-        backgroundColor:
-          jadwal.mata_kuliah?.warna || getCourseColor(jadwal.mata_kuliah?.nama_lengkap || ''),
-      }}
+      } ${isPengganti ? 'z-10' : ''}`}
+      style={
+        isPengganti
+          ? {
+              background: `linear-gradient(${bgColor}, ${bgColor}) padding-box, repeating-linear-gradient(45deg, #facc15, #facc15 10px, #ffffff 10px, #ffffff 20px) border-box`,
+              border: '4px solid transparent',
+            }
+          : {
+              backgroundColor: bgColor,
+            }
+      }
       title={
         onClick ? 'Click for details' : `${jadwal.mata_kuliah?.nama_lengkap} - ${jadwal.kelas}`
       }


### PR DESCRIPTION
Visually distinguish "Jadwal Pengganti" across components by adding a diagonal yellow striped highlight. Legend squares in JadwalClientPage and DashboardCharts were enlarged and switched to a dual-background (base muted color + repeating diagonal stripe) with a transparent border to create the striped effect. ScheduleCell now computes a bgColor variable and uses the same striped background + transparent border for pengganti entries, falling back to a plain backgroundColor for regular entries. Also adjusted regular legend and cell sizing and removed the previous ring-based styling in favor of the bordered gradient approach for a consistent look.