### PR TITLE
feat (pelanggaran) : Add RPC and UI sorting for pelanggaran rekap

### DIFF
--- a/src/app/(dashboard)/pelanggaran-rekap/PelanggaranRekapClient.tsx
+++ b/src/app/(dashboard)/pelanggaran-rekap/PelanggaranRekapClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { Filter, Search, Loader2 } from 'lucide-react';
+import { Filter, Search, Loader2, ArrowUpDown } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
@@ -39,23 +39,24 @@ interface Props {
 
 export default function PelanggaranRekapClient({ initialTahunAjaranList }: Props) {
   const [tahunAjaran, setTahunAjaran] = React.useState(initialTahunAjaranList[0] || '');
-  const [modul, setModul] = React.useState<string>('1');
+  const [modul, setModul] = React.useState<string>('all');
   const [minCount, setMinCount] = React.useState<number>(1);
   const [loading, setLoading] = React.useState(false);
   const [data, setData] = React.useState<PelanggaranSummaryEntry[]>([]);
   const [mounted, setMounted] = React.useState(false);
+  const [sortConfig, setSortConfig] = React.useState<{ key: 'mk' | 'asprak'; direction: 'asc' | 'desc' } | null>(null);
 
   React.useEffect(() => {
     setMounted(true);
     if (initialTahunAjaranList[0]) {
-      handleFetch(initialTahunAjaranList[0], '1', 1);
+      handleFetch(initialTahunAjaranList[0], 'all', 1);
     }
   }, [initialTahunAjaranList]);
 
   async function handleFetch(t: string, m: string, c: number) {
     setLoading(true);
     try {
-      const modulVal = Number(m);
+      const modulVal = m === 'all' ? 0 : Number(m);
       const res = await fetchPelanggaranSummary(t, modulVal, c);
       if (res.ok) {
         setData(res.data || []);
@@ -116,12 +117,13 @@ export default function PelanggaranRekapClient({ initialTahunAjaranList }: Props
               </div>
 
               <div className="space-y-1.5">
-                <label className="text-xs font-medium text-muted-foreground">Batas Modul</label>
+                <label className="text-xs font-medium text-muted-foreground">Target Modul</label>
                 <Select value={modul} onValueChange={setModul}>
                   <SelectTrigger className="h-9 w-full">
                     <SelectValue placeholder="Pilih Modul" />
                   </SelectTrigger>
                   <SelectContent>
+                    <SelectItem value="all">Semua Modul</SelectItem>
                     {Array.from({ length: 16 }, (_, i) => (
                       <SelectItem key={i + 1} value={String(i + 1)}>
                         Modul {i + 1}
@@ -168,6 +170,36 @@ export default function PelanggaranRekapClient({ initialTahunAjaranList }: Props
           }))
         );
 
+        const sortedViolations = [...flatViolations];
+        if (sortConfig !== null) {
+          sortedViolations.sort((a, b) => {
+            let aValue = '';
+            let bValue = '';
+            if (sortConfig.key === 'mk') {
+               aValue = a.jadwal?.mata_kuliah?.praktikum?.nama ?? '';
+               bValue = b.jadwal?.mata_kuliah?.praktikum?.nama ?? '';
+            } else if (sortConfig.key === 'asprak') {
+               aValue = a._kode_asprak ?? '';
+               bValue = b._kode_asprak ?? '';
+            }
+            if (aValue < bValue) {
+              return sortConfig.direction === 'asc' ? -1 : 1;
+            }
+            if (aValue > bValue) {
+              return sortConfig.direction === 'asc' ? 1 : -1;
+            }
+            return 0;
+          });
+        }
+
+        const handleSort = (key: 'mk' | 'asprak') => {
+          let direction: 'asc' | 'desc' = 'asc';
+          if (sortConfig && sortConfig.key === key && sortConfig.direction === 'asc') {
+            direction = 'desc';
+          }
+          setSortConfig({ key, direction });
+        };
+
         return (
           <div className="card glass border border-border/50 overflow-hidden">
             <div className="px-6 py-4 flex items-center justify-between border-b border-border/50 bg-muted/20">
@@ -179,8 +211,24 @@ export default function PelanggaranRekapClient({ initialTahunAjaranList }: Props
                 <Table className="table-fixed w-full">
                   <TableHeader>
                     <TableRow>
-                      <TableHead className="w-[20%]">MK</TableHead>
-                      <TableHead className="w-[18%]">Kode Asprak</TableHead>
+                      <TableHead 
+                        className="w-[20%] cursor-pointer select-none hover:bg-muted/50 transition-colors" 
+                        onClick={() => handleSort('mk')}
+                      >
+                        <div className="flex items-center gap-2">
+                          MK
+                          <ArrowUpDown className="h-4 w-4 text-muted-foreground" />
+                        </div>
+                      </TableHead>
+                      <TableHead 
+                        className="w-[18%] cursor-pointer select-none hover:bg-muted/50 transition-colors" 
+                        onClick={() => handleSort('asprak')}
+                      >
+                        <div className="flex items-center gap-2">
+                          Kode Asprak
+                          <ArrowUpDown className="h-4 w-4 text-muted-foreground" />
+                        </div>
+                      </TableHead>
                       <TableHead className="w-[14%] text-center">Kelas</TableHead>
                       <TableHead className="w-[20%]">Jenis</TableHead>
                       <TableHead className="w-[14%] text-center">Modul</TableHead>
@@ -224,7 +272,7 @@ export default function PelanggaranRekapClient({ initialTahunAjaranList }: Props
                         </TableCell>
                       </TableRow>
                     ) : (
-                      flatViolations.map((v) => (
+                      sortedViolations.map((v) => (
                         <TableRow key={v.id} className="hover:bg-muted/50 transition-colors">
                           <TableCell className="text-sm truncate">
                             <div className="font-medium truncate">

--- a/src/services/pelanggaranService.ts
+++ b/src/services/pelanggaranService.ts
@@ -412,26 +412,40 @@ export async function getPelanggaranSummary(
 ): Promise<PelanggaranSummaryEntry[]> {
   const supabase = supabaseClient || globalAdmin;
 
-  let query = supabase.from('pelanggaran').select(PELANGGARAN_SELECT);
+  // Allow modul to be undefined or 0, pass 0 to RPC
+  const targetModul = modul || 0;
 
-  if (modul) {
-    query = query.lte('modul', modul);
-  }
+  // 1. Fetch filtered violation IDs from the database RPC
+  const { data: idData, error: rpcError } = await supabase.rpc('get_filtered_pelanggaran_ids', {
+    p_tahun_ajaran: tahunAjaran,
+    p_target_modul: targetModul,
+    p_min_rank: minCount,
+  });
 
-  const { data, error } = await query;
-  if (error) {
-    logger.error('Error fetching violation summary:', error);
+  if (rpcError) {
+    logger.error('Error calling get_filtered_pelanggaran_ids:', rpcError);
     return [];
   }
 
-  // Client-side filter for tahun_ajaran as it's deep in relations
-  const violations = (data as Pelanggaran[]).filter((p) => {
-    const mk = p.jadwal?.mata_kuliah as any;
-    return mk?.praktikum?.tahun_ajaran === tahunAjaran;
-  });
+  const ids = idData?.map((row: any) => row.id) || [];
+  if (ids.length === 0) return [];
 
+  // 2. Fetch full related data for those IDs
+  const { data, error } = await supabase
+    .from('pelanggaran')
+    .select(PELANGGARAN_SELECT)
+    .in('id', ids)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    logger.error('Error fetching violation summary details:', error);
+    return [];
+  }
+
+  const violations = data as Pelanggaran[];
   const summaryMap = new Map<string, PelanggaranSummaryEntry>();
 
+  // 3. Group by asprak (formatting for the frontend, not for logic)
   for (const v of violations) {
     const asprakId = v.id_asprak;
     if (!asprakId) continue;
@@ -450,7 +464,8 @@ export async function getPelanggaranSummary(
     entry.violations.push(v);
   }
 
-  return Array.from(summaryMap.values())
-    .filter((entry) => entry.total_pelanggaran >= minCount)
-    .sort((a, b) => b.total_pelanggaran - a.total_pelanggaran);
+  // Filtering is already handled by the DB, just sort by total_pelanggaran descending
+  return Array.from(summaryMap.values()).sort(
+    (a, b) => b.total_pelanggaran - a.total_pelanggaran
+  );
 }

--- a/supabase/rpc_get_filtered_pelanggaran_ids.sql
+++ b/supabase/rpc_get_filtered_pelanggaran_ids.sql
@@ -1,0 +1,31 @@
+-- Script untuk membuat fungsi pencarian pelanggaran berdasarkan ranking global
+-- Silakan jalankan script ini di SQL Editor Supabase Anda
+
+CREATE OR REPLACE FUNCTION get_filtered_pelanggaran_ids(
+    p_tahun_ajaran TEXT,
+    p_target_modul INT,
+    p_min_rank INT
+)
+RETURNS TABLE ( id UUID ) AS $$
+BEGIN
+    RETURN QUERY
+    WITH RankedViolations AS (
+        SELECT 
+            p.id,
+            p.modul,
+            ROW_NUMBER() OVER (
+                PARTITION BY p.id_asprak 
+                ORDER BY p.modul ASC, p.created_at ASC
+            ) as global_rank
+        FROM pelanggaran p
+        INNER JOIN jadwal j ON p.id_jadwal = j.id
+        INNER JOIN mata_kuliah mk ON j.id_mk = mk.id
+        INNER JOIN praktikum pr ON mk.id_praktikum = pr.id
+        WHERE pr.tahun_ajaran = p_tahun_ajaran
+    )
+    SELECT rv.id
+    FROM RankedViolations rv
+    WHERE (p_target_modul IS NULL OR p_target_modul = 0 OR rv.modul = p_target_modul)
+      AND rv.global_rank >= p_min_rank;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
Introduce a DB RPC and client/server changes to move filtering into the database and add client sorting.

- Add Supabase RPC get_filtered_pelanggaran_ids to compute filtered pelanggaran IDs by tahun_ajaran, target modul, and min rank.
- Update pelanggaranService.getPelanggaranSummary to call the RPC, fetch full pelanggaran rows by returned IDs, and rely on DB filtering (remove deep client-side tahun_ajaran filtering). Log RPC errors and return early on no IDs.
- Change modul handling so 'all' / 0 means no modul filter and pass 0 to the RPC when appropriate.
- Update PelanggaranRekapClient: default modul to 'all', rename label to "Target Modul", add "Semua Modul" option, include ArrowUpDown icon and implement sortable table headers for MK and Kode Asprak with sort state and handler; use sortedViolations for rendering.

These changes push heavy filtering to the DB for performance and add a simple UI sorting layer for better UX.